### PR TITLE
chore: make jadarsie the sole approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,2 @@
 approvers:
-- CecileRobertMichon
-- devigned
-- jackfrancis
 - jadarsie
-- jsturtevant
-- marosset
-- mboersma
-- ritazh


### PR DESCRIPTION
**Reason for Change**:

Removing `azure/aks-engine` approvers from OWNERS.