### PR TITLE
chore: upgrade runc to v1.1.4

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_install.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_install.sh
@@ -108,13 +108,8 @@ installRunc() {
   local v
   local url
   v=$(runc --version | head -n 1 | cut -d" " -f3)
-  if [[ $v != "1.1.2" ]]; then
-    url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
-    if [[ -n "${url:-}" ]]; then
-      DEB="${url##*/}"
-      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit 184
-      dpkg_install 20 30 /tmp/${DEB} || exit 184
-    fi
+  if [[ $v != "1.1.4" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.1.4* --allow-downgrades || exit 27
   fi
 }
 installMoby() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17622,13 +17622,8 @@ installRunc() {
   local v
   local url
   v=$(runc --version | head -n 1 | cut -d" " -f3)
-  if [[ $v != "1.1.2" ]]; then
-    url=${MS_APT_REPO}/ubuntu/${UBUNTU_RELEASE}/multiarch/prod/pool/main/m/moby-runc/moby-runc_1.1.2%2Bazure-ubuntu${UBUNTU_RELEASE}u1_amd64.deb
-    if [[ -n "${url:-}" ]]; then
-      DEB="${url##*/}"
-      retrycmd_no_stats 120 5 25 curl -fsSL ${url} >/tmp/${DEB} || exit 184
-      dpkg_install 20 30 /tmp/${DEB} || exit 184
-    fi
+  if [[ $v != "1.1.4" ]]; then
+    apt_get_install 20 30 120 moby-runc=1.1.4* --allow-downgrades || exit 27
   fi
 }
 installMoby() {


### PR DESCRIPTION
**Reason for Change**:

Upgrading `runc` to v1.1.4 as this particular version is available in `packages.microsoft.com` for both UbuntuServer 18.04 and 20.04.
