### PR TITLE
ci: Linux VHD pipeline supports Ubuntu 20.04

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -13,7 +13,7 @@ jobs:
   strategy:
     maxParallel: 0
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
 
   container: dev1
 

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -26,7 +26,7 @@ jobs:
   strategy:
     maxParallel: 0
   pool:
-      vmImage: 'Ubuntu 18.04'
+      vmImage: 'Ubuntu 20.04'
 
   container: dev1
 

--- a/.pipelines/vhd-builder.yaml
+++ b/.pipelines/vhd-builder.yaml
@@ -5,7 +5,7 @@ variables:
   CONTAINER_IMAGE: 'mcr.microsoft.com/oss/azcu/go-dev:v1.32.3'
 
 pool:
-  vmImage: 'Ubuntu 18.04'
+  vmImage: 'Ubuntu 20.04'
 steps:
 - script: |
     docker run --rm \

--- a/vhd/packer/init-variables.sh
+++ b/vhd/packer/init-variables.sh
@@ -51,6 +51,14 @@ fi
 
 echo "storage name: ${STORAGE_ACCOUNT_NAME}"
 
+echo "UBUNTU_SKU set to ${UBUNTU_SKU}"
+UBUNTU_OFFER="UbuntuServer"
+UBUNTU_VER="18.04"
+if [[ "${UBUNTU_SKU}" == "20.04" ]]; then
+	UBUNTU_OFFER="0001-com-ubuntu-server-focal"
+	UBUNTU_VER="20_04"
+fi
+
 cat <<EOF > vhd/packer/settings.json
 {
   "subscription_id": "${SUBSCRIPTION_ID}",
@@ -61,6 +69,8 @@ cat <<EOF > vhd/packer/settings.json
   "location": "${AZURE_LOCATION}",
   "storage_account_name": "${STORAGE_ACCOUNT_NAME}",
   "vm_size": "${AZURE_VM_SIZE}",
+  "ubuntu_offer": "${UBUNTU_OFFER}",
+  "ubuntu_sku": "${UBUNTU_VER}",
   "create_time": "${CREATE_TIME}"
 }
 EOF

--- a/vhd/packer/vhd-image-builder.json
+++ b/vhd/packer/vhd-image-builder.json
@@ -9,8 +9,7 @@
         "build_number": "{{env `BUILD_NUMBER`}}",
         "build_id": "{{env `BUILD_ID`}}",
         "commit": "{{env `GIT_VERSION`}}",
-        "feature_flags": "{{env `FEATURE_FLAGS`}}",
-        "ubuntu_sku": "{{env `UBUNTU_SKU`}}"
+        "feature_flags": "{{env `FEATURE_FLAGS`}}"
     },
     "builders": [
         {
@@ -26,8 +25,8 @@
             "os_type": "Linux",
             "os_disk_size_gb": 30,
             "image_publisher": "Canonical",
-            "image_offer": "UbuntuServer",
-            "image_sku": "{{user `ubuntu_sku`}}-LTS",
+            "image_offer": "{{user `ubuntu_offer`}}",
+            "image_sku": "{{user `ubuntu_sku`}}-lts",
             "image_version": "latest",
             "azure_tags": {
                 "os": "Linux",


### PR DESCRIPTION
**Reason for Change**:

Tweaking the Linux VHD pipeline so it can build VHDs based on Ubuntu Server 18.04 OR 20.04.
