### PR TITLE
fix: ensure eth0 addr is set to NIC's primary addr

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_main.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_main.sh
@@ -181,6 +181,13 @@ if [[ -n ${MASTER_NODE} ]]; then
   {{/* this step configures all certs */}}
   {{/* both configs etcd/cosmos */}}
   time_metric "ConfigureSecrets" configureSecrets
+
+  {{/* HACK: in case a control plane node starts with incorrectly defined cloud-init IPs */}}
+  if grep -q -E '^ +addresses:|^ +- ' /etc/netplan/50-cloud-init.yaml; then
+    x=$(grep -v -E '^ +addresses:|^ +- ' /etc/netplan/50-cloud-init.yaml)
+    echo "$x" >/etc/netplan/50-cloud-init.yaml
+    netplan apply
+  fi
 fi
 
 {{/* configure etcd if we are configured for etcd */}}

--- a/pkg/api/defaults-sysctld.go
+++ b/pkg/api/defaults-sysctld.go
@@ -14,6 +14,7 @@ func (cs *ContainerService) setSysctlDConfig() {
 		"net.ipv4.neigh.default.gc_thresh1": "4096",
 		"net.ipv4.neigh.default.gc_thresh2": "8192",
 		"net.ipv4.neigh.default.gc_thresh3": "16384",
+		// "kernel.dmesg_restrict":             "0", // Uncomment to grant non-priviledged users access to dmesg
 	}
 
 	if cs.Properties.OrchestratorProfile.KubernetesConfig.NeedsContainerd() {

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -17966,6 +17966,13 @@ if [[ -n ${MASTER_NODE} ]]; then
   {{/* this step configures all certs */}}
   {{/* both configs etcd/cosmos */}}
   time_metric "ConfigureSecrets" configureSecrets
+
+  {{/* HACK: in case a control plane node starts with incorrectly defined cloud-init IPs */}}
+  if grep -q -E '^ +addresses:|^ +- ' /etc/netplan/50-cloud-init.yaml; then
+    x=$(grep -v -E '^ +addresses:|^ +- ' /etc/netplan/50-cloud-init.yaml)
+    echo "$x" >/etc/netplan/50-cloud-init.yaml
+    netplan apply
+  fi
 fi
 
 {{/* configure etcd if we are configured for etcd */}}


### PR DESCRIPTION
**Reason for Change**:

Fix an issue where multi-master clusters provision fails if distro is set to `ubuntu-18` or `ubuntu-20.04`, and network plugin is set to `azure`.

Cloud-init network configuration does not set eth0's address to the NIC's primary address. This breaks the etcd cluster as the cluster members do not trust requests from unexpected sources.