### PR TITLE
ci: e2e PR check does not use MSI

### DIFF
--- a/.pipelines/e2e-job-template.yaml
+++ b/.pipelines/e2e-job-template.yaml
@@ -32,7 +32,6 @@ jobs:
     RETAIN_SSH: false
     ENABLE_KMS_ENCRYPTION: ${{ parameters.enableKMSEncryption }}
     SUBSCRIPTION_ID: '$(SUBSCRIPTION_ID_E2E_KUBERNETES)'
-    MSI_USER_ASSIGNED_ID: '$(MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E)'
     CONTAINER_RUNTIME: ${{ parameters.containerRuntime }}
     BLOCK_SSH: ${{ parameters.runSSHTests }}
 

--- a/.pipelines/e2e-step-template.yaml
+++ b/.pipelines/e2e-step-template.yaml
@@ -18,6 +18,7 @@ steps:
       export CLIENT_SECRET=$(SERVICE_PRINCIPAL_CLIENT_SECRET_E2E_KUBERNETES)
       export CLIENT_OBJECTID=$(SERVICE_PRINCIPAL_OBJECT_ID_E2E_KUBERNETES)
       export AZURE_CORE_ONLY_SHOW_ERRORS=True
+      export USE_MANAGED_IDENTITY=false
       make test-kubernetes
     displayName: ginkgo k8s e2e tests
   - task: PublishPipelineArtifact@0

--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -36,7 +36,6 @@ jobs:
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
     GOROOT: '/usr/local/go' # Go installation path
     GOPATH: '$(Agent.TempDirectory)/go' # Go workspace path
-    MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E: ''
     REGIONS: ''
     SUBSCRIPTION_ID_E2E_KUBERNETES: ''
     TENANT_ID: ''

--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -4,7 +4,7 @@
         "orchestratorProfile": {
             "kubernetesConfig": {
                 "useCloudControllerManager": true,
-                "useManagedIdentity": true,
+                "useManagedIdentity": false,
                 "addons": [
                     {
                         "name": "coredns",

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -4,7 +4,7 @@
     "orchestratorProfile": {
       "kubernetesConfig": {
         "useCloudControllerManager": true,
-        "useManagedIdentity": true,
+        "useManagedIdentity": false,
         "clusterSubnet": "10.239.0.0/16",
         "addons": [
           {

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas-multimaster.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "kubernetesConfig": {
-        "useManagedIdentity": true,
+        "useManagedIdentity": false,
         "userAssignedID": "aksenginetestid"
       }
     },

--- a/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
+++ b/examples/e2e-tests/userassignedidentity/vmas/kubernetes-vmas.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "kubernetesConfig": {
-        "useManagedIdentity": true,
+        "useManagedIdentity": false,
         "userAssignedID": "aksenginetestid"
       }
     },

--- a/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
+++ b/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "kubernetesConfig": {
-        "useManagedIdentity": true,
+        "useManagedIdentity": false,
         "userAssignedID": "aksenginetestid"
       }
     },


### PR DESCRIPTION
**Reason for Change**:

The E2E PR check only validate non-MSI cluster definitions as MSI is not supported on ASH.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
