### PR TITLE
ci: e2e PR check does not use custom VNET

### DIFF
--- a/.pipelines/pr-e2e.yaml
+++ b/.pipelines/pr-e2e.yaml
@@ -67,8 +67,8 @@ jobs:
   parameters:
     name: 'k8s_1_22_docker_e2e'
     k8sRelease: '1.22'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
+    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json'
+    createVNET: false
     enableKMSEncryption: false
     containerRuntime: 'docker'
     runSSHTests: true
@@ -77,8 +77,8 @@ jobs:
   parameters:
     name: 'k8s_1_23_docker_e2e'
     k8sRelease: '1.23'
-    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition.json'
-    createVNET: true
+    apimodel: 'examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json'
+    createVNET: false
     enableKMSEncryption: false
     containerRuntime: 'docker'
     runSSHTests: true


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:

The E2E PR check only validate AvailabilitySet node pools as VMSS is not supported on ASH.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
