### PR TITLE
ci: e2e PR check does not use AvailabilitySets

### DIFF
--- a/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition-no-vnet.json
@@ -37,7 +37,7 @@
                 "diskSizesGB": [
                     128
                 ],
-                "availabilityProfile": "VirtualMachineScaleSets",
+                "availabilityProfile": "AvailabilitySet",
                 "osDiskCachingType": "ReadOnly",
                 "dataDiskCachingType": "ReadWrite",
                 "availabilityZones": [
@@ -50,30 +50,8 @@
                 "count": 1,
                 "vmSize": "Standard_D2s_v3",
                 "OSDiskSizeGB": 256,
-                "availabilityProfile": "VirtualMachineScaleSets",
+                "availabilityProfile": "AvailabilitySet",
                 "osType": "Windows",
-                "availabilityZones": [
-                    "1",
-                    "2"
-                ]
-            },
-            {
-                "name": "pool1804",
-                "count": 1,
-                "vmSize": "Standard_D2_v3",
-                "distro": "ubuntu-18.04",
-                "availabilityProfile": "VirtualMachineScaleSets",
-                "availabilityZones": [
-                    "1",
-                    "2"
-                ]
-            },
-            {
-                "name": "pool1804gen2",
-                "count": 1,
-                "vmSize": "Standard_D2s_v3",
-                "distro": "ubuntu-18.04-gen2",
-                "availabilityProfile": "VirtualMachineScaleSets",
                 "availabilityZones": [
                     "1",
                     "2"

--- a/examples/e2e-tests/kubernetes/release/default/definition.json
+++ b/examples/e2e-tests/kubernetes/release/default/definition.json
@@ -41,7 +41,7 @@
         "diskSizesGB": [
           128
         ],
-        "availabilityProfile": "VirtualMachineScaleSets",
+        "availabilityProfile": "AvailabilitySet",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "osDiskCachingType": "ReadOnly",
         "dataDiskCachingType": "ReadWrite",
@@ -55,33 +55,9 @@
         "count": 1,
         "vmSize": "Standard_D2s_v3",
         "OSDiskSizeGB": 256,
-        "availabilityProfile": "VirtualMachineScaleSets",
+        "availabilityProfile": "AvailabilitySet",
         "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "osType": "Windows",
-        "availabilityZones": [
-          "1",
-          "2"
-        ]
-      },
-      {
-        "name": "pool1804",
-        "count": 1,
-        "vmSize": "Standard_D2_v3",
-        "distro": "ubuntu-18.04",
-        "availabilityProfile": "VirtualMachineScaleSets",
-        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
-        "availabilityZones": [
-          "1",
-          "2"
-        ]
-      },
-      {
-        "name": "pool1804gen2",
-        "count": 1,
-        "vmSize": "Standard_D2s_v3",
-        "distro": "ubuntu-18.04-gen2",
-        "availabilityProfile": "VirtualMachineScaleSets",
-        "vnetSubnetId": "/subscriptions/SUB_ID/resourceGroups/RG_NAME/providers/Microsoft.Network/virtualNetworks/VNET_NAME/subnets/SUBNET_NAME",
         "availabilityZones": [
           "1",
           "2"

--- a/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
+++ b/examples/e2e-tests/kubernetes/windows/hybrid/definition.json
@@ -11,14 +11,14 @@
         "name": "linuxpool1",
         "count": 1,
         "vmSize": "Standard_D2s_v3",
-        "availabilityProfile": "VirtualMachineScaleSets",
+        "availabilityProfile": "AvailabilitySet",
         "storageProfile": "Ephemeral"
       },
       {
         "name": "agentwfast",
         "count": 2,
         "vmSize": "Standard_D2s_v3",
-        "availabilityProfile": "VirtualMachineScaleSets",
+        "availabilityProfile": "AvailabilitySet",
         "osType": "Windows",
         "storageProfile": "Ephemeral"
       }

--- a/examples/e2e-tests/kubernetes/zones/definition.json
+++ b/examples/e2e-tests/kubernetes/zones/definition.json
@@ -5,7 +5,7 @@
             "count": 5,
             "dnsPrefix": "",
             "vmSize": "Standard_DS2_v2",
-            "availabilityProfile": "VirtualMachineScaleSets",
+            "availabilityProfile": "AvailabilitySet",
             "availabilityZones": [
                 "1",
                 "2"
@@ -16,7 +16,7 @@
                 "name": "agentpool",
                 "count": 4,
                 "vmSize": "Standard_DS2_v2",
-                "availabilityProfile": "VirtualMachineScaleSets",
+                "availabilityProfile": "AvailabilitySet",
                 "availabilityZones": [
                     "1",
                     "2"

--- a/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
+++ b/examples/e2e-tests/userassignedidentity/vmss/kubernetes-vmss.json
@@ -11,14 +11,14 @@
       "count": 1,
       "dnsPrefix": "",
       "vmSize": "Standard_D2_v3",
-      "availabilityProfile": "VirtualMachineScaleSets"
+      "availabilityProfile": "AvailabilitySet"
     },
     "agentPoolProfiles": [
       {
         "name": "agentpool1",
         "count": 2,
         "vmSize": "Standard_D2_v3",
-        "availabilityProfile": "VirtualMachineScaleSets"
+        "availabilityProfile": "AvailabilitySet"
       }
     ],
     "linuxProfile": {


### PR DESCRIPTION
**Reason for Change**:

The E2E PR checks only validate VMAS cluster definitions as VMSS is not supported on ASH.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
