### PR TITLE
chore: set fsType to ext4 in supported storage classes

### DIFF
--- a/parts/k8s/addons/azure-cloud-provider.yaml
+++ b/parts/k8s/addons/azure-cloud-provider.yaml
@@ -95,6 +95,7 @@ parameters:
   skuName: Standard_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}
@@ -118,6 +119,7 @@ parameters:
   skuName: Premium_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}
@@ -141,6 +143,7 @@ parameters:
   skuName: Standard_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -5894,6 +5894,7 @@ parameters:
   skuName: Standard_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}
@@ -5917,6 +5918,7 @@ parameters:
   skuName: Premium_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}
@@ -5940,6 +5942,7 @@ parameters:
   skuName: Standard_LRS
   kind: managed
   cachingMode: ReadOnly
+  fsType: ext4
 reclaimPolicy: Delete
 allowVolumeExpansion: true
   {{- if HasAgentPoolAvailabilityZones}}


### PR DESCRIPTION
**Reason for Change**:

It seems that the default value of `fsGroupPolicy` of `CSIDriver` resources (`ReadWriteOnceWithFSType`) requires storage classes to explicitly define their `fsType` to successfully modify PV permissions when required.

This PR explicitly set `fsType` to its default `ext4`. 

**Issue Fixed**:

Related to #67

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
