### PR TITLE
fix: CoreDNS image not updated after cluster upgrade

### DIFF
--- a/parts/k8s/addons/coredns.yaml
+++ b/parts/k8s/addons/coredns.yaml
@@ -5,14 +5,14 @@ metadata:
   namespace: kube-system
   labels:
       kubernetes.io/cluster-service: "true"
-      addonmanager.kubernetes.io/mode: EnsureExists
+      addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
 - apiGroups:
@@ -46,7 +46,7 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -63,7 +63,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
     import conf.d/Corefile*
@@ -111,7 +111,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   {{- /* replicas: not specified here:
   1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -253,7 +253,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: CoreDNS
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     k8s-app: kube-dns
@@ -276,14 +276,14 @@ metadata:
   namespace: kube-system
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: coredns-autoscaler
 rules:
   - apiGroups: [""]
@@ -304,7 +304,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: coredns-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -323,7 +323,7 @@ metadata:
   labels:
     k8s-app: coredns-autoscaler
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -12882,14 +12882,14 @@ metadata:
   namespace: kube-system
   labels:
       kubernetes.io/cluster-service: "true"
-      addonmanager.kubernetes.io/mode: EnsureExists
+      addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 rules:
 - apiGroups:
@@ -12923,7 +12923,7 @@ metadata:
     rbac.authorization.kubernetes.io/autoupdate: "true"
   labels:
     kubernetes.io/bootstrapping: rbac-defaults
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: system:coredns
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12940,7 +12940,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 data:
   Corefile: |
     import conf.d/Corefile*
@@ -12988,7 +12988,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   {{- /* replicas: not specified here:
   1. In order to make Addon Manager do not reconcile this replicas parameter.
@@ -13130,7 +13130,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: CoreDNS
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     k8s-app: kube-dns
@@ -13153,14 +13153,14 @@ metadata:
   namespace: kube-system
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: coredns-autoscaler
 rules:
   - apiGroups: [""]
@@ -13181,7 +13181,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     k8s-addon: coredns.addons.k8s.io
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
   name: coredns-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13200,7 +13200,7 @@ metadata:
   labels:
     k8s-app: coredns-autoscaler
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: EnsureExists
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
**Reason for Change**:

Changing the CoreDNS addon manager mode from `EnsureExist` to `Reconcile`.

The cluster upgrade process produces the correct addon spec (/etc/kubernetes/addons/coredns.yaml) but the new spec is not applied until the CoreDNS deployment is kubectl-deleted. The `Reconcile` addon manager mode will fix this inconvenient.

The custom `Corefile` configmap keeps the `EnsureExist` mode so cluster upgrades do not erase user-provided overrides.

**Issue Fixed**:

Related to #66

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
