### PR TITLE
fix: kubernetes-azurestack.json uses distro aks-ubuntu-20.04

### DIFF
--- a/examples/azure-stack/kubernetes-azurestack.json
+++ b/examples/azure-stack/kubernetes-azurestack.json
@@ -36,7 +36,7 @@
         },
         "masterProfile": {
             "dnsPrefix": "",
-            "distro": "aks-ubuntu-18.04",
+            "distro": "aks-ubuntu-20.04",
             "count": 3,
             "vmSize": "Standard_DS2_v2"
         },
@@ -45,7 +45,7 @@
                 "name": "linuxpool",
                 "count": 3,
                 "vmSize": "Standard_D2_v2",
-                "distro": "aks-ubuntu-18.04",
+                "distro": "aks-ubuntu-20.04",
                 "availabilityProfile": "AvailabilitySet",
                 "AcceleratedNetworkingEnabled": false
             }


### PR DESCRIPTION
kubernetes-azurestack.json uses distro aks-ubuntu-20.04 instead of aks-ubuntu-18.04