### PR TITLE
chore: upgrade coredns to v1.9.4

### DIFF
--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -83,7 +83,7 @@ var kubernetesImageBaseDefaultImages = map[string]map[string]string{
 		common.DashboardAddonName:                   "oss/kubernetes/dashboard:v2.0.4", // deprecated
 		common.DashboardMetricsScraperContainerName: "oss/kubernetes/metrics-scraper:v1.0.4",
 		common.ExecHealthZComponentName:             "oss/kubernetes/exechealthz:1.2",
-		common.CoreDNSAddonName:                     "oss/kubernetes/coredns:1.8.6",
+		common.CoreDNSAddonName:                     "oss/kubernetes/coredns:v1.9.4",
 		common.KubeDNSAddonName:                     "oss/kubernetes/k8s-dns-kube-dns:1.15.4",
 		common.DNSMasqComponentName:                 "oss/kubernetes/k8s-dns-dnsmasq-nanny:1.15.4",
 		common.DNSSidecarComponentName:              "oss/kubernetes/k8s-dns-sidecar:1.14.10",

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -156,10 +156,11 @@ for CLUSTER_AUTOSCALER_VERSION in ${CLUSTER_AUTOSCALER_VERSIONS}; do
 done
 
 CORE_DNS_VERSIONS="
+1.9.4
 1.8.6
 "
 for CORE_DNS_VERSION in ${CORE_DNS_VERSIONS}; do
-    CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/coredns:${CORE_DNS_VERSION}"
+    CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/coredns:v${CORE_DNS_VERSION}"
     loadContainerImage ${CONTAINER_IMAGE}
     echo "  - ${CONTAINER_IMAGE}" >> ${VHD_LOGS_FILEPATH}
 done


### PR DESCRIPTION
**Reason for Change**:

https://github.com/coredns/coredns/releases/tag/v1.9.4