### PR TITLE
bug: enforce each addon manager pod

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -423,16 +423,23 @@ fi
 }
 
 ensureKubeAddonManager() {
+  local kam_pod=kube-addon-manager-${HOSTNAME}
+  {{/* Wait 30 sec for kube-addon-manager to become Ready */}}
+  if ! retrycmd 6 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system; then
+    {{/* Restart kubelet if kube-addon-manager is not Ready after timeout */}}
+    systemctl_restart 3 5 30 kubelet
+  fi
   {{/* Wait 5 mins for kube-addon-manager to become Ready */}}
-  if ! retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s -l app=kube-addon-manager po -n kube-system; then
+  if ! retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system; then
     {{/* Restart kubelet if kube-addon-manager is not Ready after 5 mins */}}
     systemctl_restart 3 5 30 kubelet
     {{/* Wait 5 more mins for kube-addon-manager to become Ready, and then return failure if not */}}
-    retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s -l app=kube-addon-manager po -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+    retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   fi
 }
 
 ensureAddons() {
+  local kam_pod=kube-addon-manager-${HOSTNAME}
 {{- if IsDashboardAddonEnabled}} {{/* Note: dashboard addon is deprecated */}}
   retrycmd 120 5 30 $KUBECTL get namespace kubernetes-dashboard || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
 {{- end}}
@@ -446,8 +453,8 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   ensureKubeAddonManager
   {{/* Manually delete any kube-addon-manager pods that point to the init directory */}}
-  for initPod in $(${KUBECTL} get pod -l app=kube-addon-manager -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
-    retrycmd 120 5 30 ${KUBECTL} delete pod $initPod -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  for initPod in $(${KUBECTL} get pod ${kam_pod} -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
+    retrycmd 120 5 30 ${KUBECTL} delete pod ${kam_pod} -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   done
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -16672,23 +16672,23 @@ fi
 }
 
 ensureKubeAddonManager() {
-  local pod_name=kube-addon-manager-${HOSTNAME}
+  local kam_pod=kube-addon-manager-${HOSTNAME}
   {{/* Wait 30 sec for kube-addon-manager to become Ready */}}
-  if ! retrycmd 6 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${pod_name} -n kube-system; then
+  if ! retrycmd 6 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system; then
     {{/* Restart kubelet if kube-addon-manager is not Ready after timeout */}}
     systemctl_restart 3 5 30 kubelet
   fi
-  {{/* Wait 2.5 mins for kube-addon-manager to become Ready */}}
-  if ! retrycmd 30 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${pod_name} -n kube-system; then
-    {{/* Restart kubelet if kube-addon-manager is not Ready after timeout */}}
+  {{/* Wait 5 mins for kube-addon-manager to become Ready */}}
+  if ! retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system; then
+    {{/* Restart kubelet if kube-addon-manager is not Ready after 5 mins */}}
     systemctl_restart 3 5 30 kubelet
-    {{/* Wait 2.5 mins more mins for kube-addon-manager to become Ready, and then return failure if not */}}
-    retrycmd 30 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${pod_name} -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+    {{/* Wait 5 more mins for kube-addon-manager to become Ready, and then return failure if not */}}
+    retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
   fi
 }
 
 ensureAddons() {
-  local pod_name=kube-addon-manager-${HOSTNAME}
+  local kam_pod=kube-addon-manager-${HOSTNAME}
 {{- if IsDashboardAddonEnabled}} {{/* Note: dashboard addon is deprecated */}}
   retrycmd 120 5 30 $KUBECTL get namespace kubernetes-dashboard || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
 {{- end}}
@@ -16702,7 +16702,9 @@ ensureAddons() {
   rm -Rf ${ADDONS_DIR}/init
   ensureKubeAddonManager
   {{/* Manually delete any kube-addon-manager pods that point to the init directory */}}
-  retrycmd 120 5 30 ${KUBECTL} delete pod ${pod_name} -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  for initPod in $(${KUBECTL} get pod ${kam_pod} -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
+    retrycmd 120 5 30 ${KUBECTL} delete pod ${kam_pod} -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  done
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
     sleep 3

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -211,7 +211,7 @@ var _ = AfterSuite(func() {
 		fmt.Println(string(stdout))
 	}
 	if cfg.DebugAfterSuite {
-		cmd := exec.Command("k", "get", "deployments,pods,svc,daemonsets,configmaps,endpoints,jobs,clusterroles,clusterrolebindings,roles,rolebindings,storageclasses,podsecuritypolicy", "--all-namespaces", "-o", "wide")
+		cmd := exec.Command("k", "get", "deployments,pods,svc,daemonsets,configmaps,endpoints,jobs,clusterroles,clusterrolebindings,roles,rolebindings,storageclasses", "--all-namespaces", "-o", "wide")
 		out, err := cmd.CombinedOutput()
 		log.Printf("%s\n", out)
 		if err != nil {
@@ -757,12 +757,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should have core kube-system componentry running", func() {
-			coreComponents := []string{
-				common.AddonManagerComponentName,
-				common.APIServerComponentName,
-				common.ControllerManagerComponentName,
-				common.KubeProxyAddonName,
-				common.SchedulerComponentName,
+			coreComponents := []string{common.KubeProxyAddonName}
+			masterPrefix := eng.ExpandedDefinition.Properties.GetMasterVMPrefix()
+			for i := 0; i < eng.ExpandedDefinition.Properties.MasterProfile.Count; i++ {
+				coreComponents = append(coreComponents, fmt.Sprintf("%s-%s%d", common.AddonManagerComponentName, masterPrefix, i))
+				coreComponents = append(coreComponents, fmt.Sprintf("%s-%s%d", common.APIServerComponentName, masterPrefix, i))
+				coreComponents = append(coreComponents, fmt.Sprintf("%s-%s%d", common.ControllerManagerComponentName, masterPrefix, i))
+				coreComponents = append(coreComponents, fmt.Sprintf("%s-%s%d", common.SchedulerComponentName, masterPrefix, i))
 			}
 			if to.Bool(eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.UseCloudControllerManager) {
 				coreComponents = append(coreComponents, common.CloudControllerManagerComponentName)
@@ -889,7 +890,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should print cluster resources", func() {
-			cmd := exec.Command("k", "get", "deployments,pods,svc,daemonsets,configmaps,endpoints,jobs,clusterroles,clusterrolebindings,roles,rolebindings,storageclasses,podsecuritypolicy", "--all-namespaces", "-o", "wide")
+			cmd := exec.Command("k", "get", "deployments,pods,svc,daemonsets,configmaps,endpoints,jobs,clusterroles,clusterrolebindings,roles,rolebindings,storageclasses", "--all-namespaces", "-o", "wide")
 			out, err := cmd.CombinedOutput()
 			log.Printf("%s\n", out)
 			if err != nil {
@@ -1853,7 +1854,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					Expect(nodeZone == pvZone).To(Equal(true))
 				}
 
-				if (cfg.CleanPVC) {
+				if cfg.CleanPVC {
 					By("Cleaning up after ourselves")
 					err = testPod.Delete(util.DefaultDeleteRetries)
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**Reason for Change**:

The bootstrap script only ensures that at least 1 addon-manager is up and running. This PR makes sure all expected instances are up and running.

Test "should have core kube-system componentry running" checks if all the expected pods are present AND running, instead of just validating if the present pods are running. Adding extra validation because addon-manager to catch regressions.