### PR TITLE
ci: gen-release-changelog wf creates branch and commit

### DIFF
--- a/.github/workflows/create-release-branch.yaml
+++ b/.github/workflows/create-release-branch.yaml
@@ -137,6 +137,10 @@ jobs:
         with:
           ref: release-${{github.event.inputs.release_version}}
           fetch-depth: 0
+      - name: setup git
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
       - name: install go
         uses: actions/setup-go@v3
         with:
@@ -151,10 +155,20 @@ jobs:
           git add releases/CHANGELOG-${{github.event.inputs.release_version}}.md
       - name: remove git-chglog binary
         run: rm -f ${GITHUB_WORKSPACE}/git-chglog
-      - name: create pull request
-        uses: peter-evans/create-pull-request@v3
-        with:
-          commit-message: 'release: ${{github.event.inputs.release_version}} CHANGELOG'
-          title: 'release: ${{github.event.inputs.release_version}} CHANGELOG'
-          body: Add CHANGELOG for upcoming ${{github.event.inputs.release_version}} release
-          branch: CHANGELOG-${{github.event.inputs.release_version}}
+      - name: create changelog branch
+        run: |
+          git commit -m "release: ${RELEASE_VER} CHANGELOG"
+          git checkout -b CHANGELOG-${RELEASE_VER}
+          git push origin CHANGELOG-${RELEASE_VER}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VER: ${{github.event.inputs.release_version}}
+      - name: print create pr instructions
+        run: |
+          BASE=release-${RELEASE_VER}
+          TITLE="release: ${RELEASE_VER} CHANGELOG"
+          BODY="Add CHANGELOG for upcoming ${RELEASE_VER} release"
+          echo "Create PR from web UI: https://github.com/${GITHUB_REPOSITORY}/pull/new/CHANGELOG-${RELEASE_VER}"
+          echo "Create PR from GH CLI: > gh pr create -b \"${BASE}\" -t \"${TITLE}\" -b \"${BODY}\" -R ${GITHUB_REPOSITORY}"
+        env:
+          RELEASE_VER: ${{github.event.inputs.release_version}}

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,9 @@ tools-install:
 tools-clean:
 	make -C hack/tools/ clean
 
+create-release-branch:
+	@./scripts/gh-create-release-branch.sh
+
 include versioning.mk
 include test.mk
 include packer.mk

--- a/scripts/gh-create-release-branch.sh
+++ b/scripts/gh-create-release-branch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+WORKFLOW_FROM_BRANCH=${WORKFLOW_FROM_BRANCH:-master}
+echo WORKFLOW_FROM_BRANCH=${WORKFLOW_FROM_BRANCH}
+
+RELEASE_REPOSITORY=${RELEASE_REPOSITORY:-Azure/aks-engine-azurestack}
+echo RELEASE_REPOSITORY=${RELEASE_REPOSITORY}
+
+if [[ -z ${RELEASE_VERSION} ]]; then
+  echo "RELEASE_VERSION is not set (e.x.: v0.76.0, v0.76.1)"
+  exit 1
+fi
+echo RELEASE_VERSION=${RELEASE_VERSION}
+
+if [[ -z ${RELEASE_FROM_BRANCH} ]]; then
+  echo "RELEASE_FROM_BRANCH is not set (e.x: master, patch-release-v0.76.1)"
+  exit 1
+fi
+echo RELEASE_FROM_BRANCH=${RELEASE_FROM_BRANCH}
+
+gh workflow run create-release-branch.yaml \
+  --ref ${WORKFLOW_FROM_BRANCH} \
+  -R ${RELEASE_REPOSITORY} \
+  -f release_version=${RELEASE_VERSION} \
+  -f from_branch=${RELEASE_FROM_BRANCH}


### PR DESCRIPTION
**Reason for Change**:

New security polices block creating PRs from a GH action. Updating the `create-release-branch` workflow so it only creates the changelog commit.

Added script to run the workflow through GH CLI:

```
RELEASE_VERSION=v0.76.0 RELEASE_FROM_BRANCH=master make create-release-branch
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
