### PR TITLE
fix: remove invalid k8s v1.24 flags

### DIFF
--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -152,6 +152,14 @@ func (cs *ContainerService) setAPIServerConfig() {
 		delete(o.KubernetesConfig.APIServerConfig, key)
 	}
 
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.24.0") {
+		// https://github.com/kubernetes/kubernetes/pull/106859
+		removedFlags124 := []string{"--address", "--insecure-bind-address", "--port", "--insecure-port"}
+		for _, key := range removedFlags124 {
+			delete(o.KubernetesConfig.APIServerConfig, key)
+		}
+	}
+
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.25.0") {
 		// https://github.com/kubernetes/kubernetes/pull/108624
 		removedFlags125 := []string{"--service-account-api-audiences"}

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -658,18 +658,6 @@ func TestAPIServerInsecureFlag(t *testing.T) {
 			version: "1.23.0",
 			found:   false,
 		},
-		{
-			version: "1.24.0",
-			found:   false,
-		},
-		{
-			version: "1.24.0-alpha.0",
-			found:   false,
-		},
-		{
-			version: "1.24.0-alpha.1-24",
-			found:   false,
-		},
 	}
 
 	for _, tt := range apiTests {
@@ -685,6 +673,46 @@ func TestAPIServerInsecureFlag(t *testing.T) {
 		if tt.found && v != "0" {
 			t.Fatalf("got unexpected '--insecure-port' API server config value for k8s v%s: %s",
 				defaultTestClusterVer, a["--insecure-port"])
+		}
+	}
+
+	apiTestsForceDelete := []apiServerTest{
+		{
+			version: "1.23.0",
+			found:   true,
+		},
+		{
+			version: "1.24.0",
+			found:   false,
+		},
+	}
+
+	for _, tt := range apiTestsForceDelete {
+		cs := CreateMockContainerService("testcluster", tt.version, 3, 2, false)
+		cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = map[string]string{
+			"--address":               "0.0.0.0",
+			"--insecure-bind-address": "0.0.0.0",
+			"--port":                  "443",
+			"--insecure-port":         "0",
+		}
+		cs.setAPIServerConfig()
+		a := cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+
+		_, found := a["--address"]
+		if found != tt.found {
+			t.Fatalf("got --address found %t want %t", found, tt.found)
+		}
+		_, found = a["--insecure-bind-address"]
+		if found != tt.found {
+			t.Fatalf("got --insecure-bind-address found %t want %t", found, tt.found)
+		}
+		_, found = a["--port"]
+		if found != tt.found {
+			t.Fatalf("got --port found %t want %t", found, tt.found)
+		}
+		_, found = a["--insecure-port"]
+		if found != tt.found {
+			t.Fatalf("got --insecure-port found %t want %t", found, tt.found)
 		}
 	}
 

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -81,6 +81,14 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		}
 	}
 
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.24.0") {
+		// https://github.com/kubernetes/kubernetes/pull/106860
+		removedFlags124 := []string{"--address", "--port"}
+		for _, key := range removedFlags124 {
+			delete(o.KubernetesConfig.ControllerManagerConfig, key)
+		}
+	}
+
 	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.25.0") {
 		// https://github.com/kubernetes/kubernetes/pull/109612
 		removedFlags125 := []string{"--deleting-pods-qps", "--deleting-pods-burst", "--register-retry-count"}

--- a/pkg/api/defaults-controller-manager_test.go
+++ b/pkg/api/defaults-controller-manager_test.go
@@ -182,3 +182,41 @@ func TestControllerManagerDefaultConfig(t *testing.T) {
 		t.Fatalf("expected controller-manager to have route-reconciliation-period set to its default value")
 	}
 }
+
+func TestControllerManagerInsecureFlag(t *testing.T) {
+	type controllerManagerTest struct {
+		version string
+		found   bool
+	}
+
+	controllerManagerTestsForceDelete := []controllerManagerTest{
+		{
+			version: "1.23.0",
+			found:   true,
+		},
+		{
+			version: "1.24.0",
+			found:   false,
+		},
+	}
+
+	for _, tt := range controllerManagerTestsForceDelete {
+		cs := CreateMockContainerService("testcluster", tt.version, 3, 2, false)
+		cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig = map[string]string{
+			"--address": "0.0.0.0",
+			"--port":    "443",
+		}
+		cs.setControllerManagerConfig()
+		a := cs.Properties.OrchestratorProfile.KubernetesConfig.ControllerManagerConfig
+
+		_, found := a["--address"]
+		if found != tt.found {
+			t.Fatalf("got --address found %t want %t", found, tt.found)
+		}
+		_, found = a["--port"]
+		if found != tt.found {
+			t.Fatalf("got --port found %t want %t", found, tt.found)
+		}
+	}
+
+}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
In Kubernetes v1.24, insecure address flags were removed.
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#deprecation
https://github.com/kubernetes/kubernetes/pull/106859
https://github.com/kubernetes/kubernetes/pull/106860
Customer with existing api-models containing such a flag got broken deployments and upgrades. This PR will automatically remove the feature flag even if the customer specifies it, if k8s version >= 1.24.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
