### PR TITLE
test: remove auditd from packages validate script

### DIFF
--- a/test/e2e/kubernetes/scripts/stig-validate.sh
+++ b/test/e2e/kubernetes/scripts/stig-validate.sh
@@ -49,3 +49,11 @@ for ((i = 0; i < ${#CONFIGS[@]}; i++))
 do
     grep -i "${CONFIGS[$i]}" /etc/ssh/sshd_config || exit 1
 done
+
+ENSURE_INSTALLED="
+auditd
+"
+
+for PACKAGE in ${ENSURE_INSTALLED}; do
+    apt list --installed | grep -E "^${PACKAGE}" || exit 1
+done

--- a/test/e2e/kubernetes/scripts/ubuntu-installed-packages-validate.sh
+++ b/test/e2e/kubernetes/scripts/ubuntu-installed-packages-validate.sh
@@ -28,7 +28,6 @@ fi
 
 ENSURE_INSTALLED="
 apt-transport-https
-auditd
 blobfuse
 ca-certificates
 chrony


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Previously, the test "should validate installed software packages" was failing because auditd was expected, but could not be found. This fix removes auditd as an expected package for all clusters.

Instead, now the stig validation test itself will verify auditd is installed, since auditd is only need for stig compliant clusters.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
