### PR TITLE
fix: add kube-addon-manager v9.1.6 to vhd

### DIFF
--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -116,7 +116,7 @@ var kubernetesImageBaseVersionedImages = map[string]map[string]map[string]string
 		"1.25": {
 			common.AddonResizerComponentName:  "addon-resizer:1.8.7",
 			common.MetricsServerAddonName:     "metrics-server/metrics-server:v0.5.0",
-			common.AddonManagerComponentName:  "kube-addon-manager-amd64:v9.1.5",
+			common.AddonManagerComponentName:  "kube-addon-manager-amd64:v9.1.6",
 			common.ClusterAutoscalerAddonName: "cluster-autoscaler:v1.18.0",
 		},
 		"1.24": {

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -127,6 +127,7 @@ done
 
 KUBE_ADDON_MANAGER_VERSIONS="
 9.1.5
+9.1.6
 "
 for KUBE_ADDON_MANAGER_VERSION in ${KUBE_ADDON_MANAGER_VERSIONS}; do
     CONTAINER_IMAGE="mcr.microsoft.com/oss/kubernetes/kube-addon-manager:v${KUBE_ADDON_MANAGER_VERSION}"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Previously, for air-gapped clusters on k8s v1.25, kube-addon-manager would be stuck on ImagePullBackOff because it could not download the specified MCR 9.1.6 image. The VHD only contains 9.1.5.
This PR adds 9.1.6 to the VHD. Also, changes the GCR kube-addon-manager image to 9.1.6.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
