### PR TITLE
ci: exclude version control information from binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ build: generate go-build
 
 .PHONY: go-build
 go-build:
-	$(GO) build $(GOFLAGS) -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(PROJECT)$(EXTENSION) $(REPO_PATH)
+	$(GO) build $(GOFLAGS) -ldflags '$(LDFLAGS)' -buildvcs=false -o $(BINDIR)/$(PROJECT)$(EXTENSION) $(REPO_PATH)
 
 .PHONY: tidy
 tidy:

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -9,7 +9,7 @@ build: clean runner-build ginkgo-build
 
 .PHONY: runner-build
 runner-build:
-	$(GO) build -tags=test -o ./$(BINDIR)/e2e-runner .
+	$(GO) build -tags=test -buildvcs=false -o ./$(BINDIR)/e2e-runner .
 
 .PHONY: ginkgo-build
 ginkgo-build:


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Go version was bumped from 1.17 to 1.19. As a result, e2e tests in cluster.sh run into this error:

```
fatal: detected dubious ownership in repository at '/aks-engine-azurestack'
To add an exception for this directory, call:
 git config --global --add safe.directory /aks-engine-azurestack
error obtaining VCS status: exit status 128
Use -buildvcs=false to disable VCS stamping.
```

This VCS behavior was introduced in go 1.18:

> The go command now embeds version control information in binaries. It includes the currently checked-out revision, commit time, and a flag indicating whether edited or untracked files are present. Version control information is embedded if the go command is invoked in a directory within a Git, Mercurial, Fossil, or Bazaar repository, and the main package and its containing main module are in the same repository. This information may be omitted using the flag -buildvcs=false.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
