### PR TITLE
fix: shorten custom data in cloud init files

### DIFF
--- a/parts/k8s/cloud-init/artifacts/cse_config.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_config.sh
@@ -3,7 +3,7 @@ NODE_INDEX=$(hostname | tail -c 2)
 NODE_NAME=$(hostname)
 KUBECTL="/usr/local/bin/kubectl --kubeconfig=/home/$ADMINUSER/.kube/config"
 ADDONS_DIR=/etc/kubernetes/addons
-POD_SECURITY_POLICY_SPEC=$ADDONS_DIR/pod-security-policy.yaml
+PSP_SPEC=$ADDONS_DIR/pod-security-policy.yaml
 ADDON_MANAGER_SPEC=/etc/kubernetes/manifests/kube-addon-manager.yaml
 GET_KUBELET_LOGS="journalctl -u kubelet --no-pager"
 
@@ -612,8 +612,8 @@ configAddons() {
   configAzurePolicyAddon
   {{end}}
   {{- if and (not HasCustomPodSecurityPolicy) IsPodSecurityPolicyAddonEnabled}}
-  wait_for_file 1200 1 $POD_SECURITY_POLICY_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  mkdir -p $ADDONS_DIR/init && cp $POD_SECURITY_POLICY_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  wait_for_file 1200 1 $PSP_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  mkdir -p $ADDONS_DIR/init && cp $PSP_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}
 }
 {{- if and HasNSeriesSKU IsNvidiaDevicePluginAddonEnabled}}

--- a/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
+++ b/parts/k8s/cloud-init/artifacts/cse_customcloud.sh
@@ -3,18 +3,18 @@
 {{- if IsCustomCloudProfile}}
   {{- if not IsAzureStackCloud}}
 ensureCustomCloudRootCertificates() {
-    CUSTOM_CLOUD_ROOT_CERTIFICATES="{{GetCustomCloudRootCertificates}}"
-    KUBE_CONTROLLER_MANAGER_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
+    CUSTOM_CLOUD_CERTS="{{GetCustomCloudRootCertificates}}"
+    KCM_FILE=/etc/kubernetes/manifests/kube-controller-manager.yaml
 
-    if [ ! -z $CUSTOM_CLOUD_ROOT_CERTIFICATES ]; then
+    if [ ! -z $CUSTOM_CLOUD_CERTS ]; then
         # Replace placeholder for ssl binding
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
-            sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KUBE_CONTROLLER_MANAGER_FILE
+        if [ -f $KCM_FILE ]; then
+            sed -i "s|<volumessl>|- name: ssl\n      hostPath:\n        path: \\/etc\\/ssl\\/certs|g" $KCM_FILE
+            sed -i "s|<volumeMountssl>|- name: ssl\n          mountPath: \\/etc\\/ssl\\/certs\n          readOnly: true|g" $KCM_FILE
         fi
 
         local i=1
-        for cert in $(echo $CUSTOM_CLOUD_ROOT_CERTIFICATES | tr ',' '\n')
+        for cert in $(echo $CUSTOM_CLOUD_CERTS | tr ',' '\n')
         do
             echo $cert | base64 -d > "/usr/local/share/ca-certificates/customCloudRootCertificate$i.crt"
             ((i++))
@@ -22,21 +22,21 @@ ensureCustomCloudRootCertificates() {
 
         update-ca-certificates
     else
-        if [ -f $KUBE_CONTROLLER_MANAGER_FILE ]; then
+        if [ -f $KCM_FILE ]; then
             # remove the placeholder for ssl binding
-            sed -i "/<volumessl>/d" $KUBE_CONTROLLER_MANAGER_FILE
-            sed -i "/<volumeMountssl>/d" $KUBE_CONTROLLER_MANAGER_FILE
+            sed -i "/<volumessl>/d" $KCM_FILE
+            sed -i "/<volumeMountssl>/d" $KCM_FILE
         fi
     fi
 }
 
 ensureCustomCloudSourcesList() {
-    CUSTOM_CLOUD_SOURCES_LIST="{{GetCustomCloudSourcesList}}"
+    CUSTOM_CLOUD_LIST="{{GetCustomCloudSourcesList}}"
 
-    if [ ! -z $CUSTOM_CLOUD_SOURCES_LIST ]; then
+    if [ ! -z $CUSTOM_CLOUD_LIST ]; then
         # Just in case, let's take a back up before we overwrite
         cp /etc/apt/sources.list /etc/apt/sources.list.backup
-        echo $CUSTOM_CLOUD_SOURCES_LIST | base64 -d > /etc/apt/sources.list
+        echo $CUSTOM_CLOUD_LIST | base64 -d > /etc/apt/sources.list
     fi
 }
   {{end}}
@@ -55,24 +55,23 @@ configureK8sCustomCloud() {
   #    "password": "$password"
   #}
   if [[ ${AUTHENTICATION_METHOD,,} == "client_certificate" ]]; then
-    SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
-    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .data)
-    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET_DECODED | jq .password)
+    SPN_DECODED=$(echo ${SERVICE_PRINCIPAL_CLIENT_SECRET} | base64 --decode)
+    SPN_CERT=$(echo $SPN_DECODED | jq .data)
+    SPN_PWD=$(echo $SPN_DECODED | jq .password)
 
     # trim the starting and ending "
-    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT#'"'}
-    SERVICE_PRINCIPAL_CLIENT_SECRET_CERT=${SERVICE_PRINCIPAL_CLIENT_SECRET_CERT%'"'}
+    SPN_CERT=${SPN_CERT#'"'}
+    SPN_CERT=${SPN_CERT%'"'}
 
-    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD#'"'}
-    SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD=${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD%'"'}
+    SPN_PWD=${SPN_PWD#'"'}
+    SPN_PWD=${SPN_PWD%'"'}
 
-    KUBERNETES_FILE_DIR=$(dirname "${azure_json_path}")
-    K8S_CLIENT_CERT_PATH="${KUBERNETES_FILE_DIR}/k8s_auth_certificate.pfx"
-    echo $SERVICE_PRINCIPAL_CLIENT_SECRET_CERT | base64 --decode >$K8S_CLIENT_CERT_PATH
+    K8S_CLIENT_CERT="$(dirname ${azure_json_path})/k8s_auth_certificate.pfx"
+    echo $SPN_CERT | base64 --decode >$K8S_CLIENT_CERT
     # shellcheck disable=SC2002,SC2005
     echo $(cat "${azure_json_path}" |
-      jq --arg K8S_CLIENT_CERT_PATH ${K8S_CLIENT_CERT_PATH} '. + {aadClientCertPath:($K8S_CLIENT_CERT_PATH)}' |
-      jq --arg SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD ${SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD} '. + {aadClientCertPassword:($SERVICE_PRINCIPAL_CLIENT_SECRET_PASSWORD)}' |
+      jq --arg K8S_CLIENT_CERT ${K8S_CLIENT_CERT} '. + {aadClientCertPath:($K8S_CLIENT_CERT)}' |
+      jq --arg SPN_PWD ${SPN_PWD} '. + {aadClientCertPassword:($SPN_PWD)}' |
       jq 'del(.aadClientSecret)') >${azure_json_path}
   fi
 

--- a/pkg/engine/templates_generated.go
+++ b/pkg/engine/templates_generated.go
@@ -16244,10 +16244,10 @@ var _k8sCloudInitArtifactsCse_configSh = []byte(`#!/bin/bash
 NODE_INDEX=$(hostname | tail -c 2)
 NODE_NAME=$(hostname)
 KUBECTL="/usr/local/bin/kubectl --kubeconfig=/home/$ADMINUSER/.kube/config"
-ADDONS_DIR=/etc/kubernetes/addons
-PSP_SPEC=$ADDONS_DIR/pod-security-policy.yaml
-ADDON_MANAGER_SPEC=/etc/kubernetes/manifests/kube-addon-manager.yaml
-GET_KUBELET_LOGS="journalctl -u kubelet --no-pager"
+AO_DIR=/etc/kubernetes/addons
+PSP_SPEC=$AO_DIR/pod-security-policy.yaml
+AOM_SPEC=/etc/kubernetes/manifests/kube-addon-manager.yaml
+K_LOG="journalctl -u kubelet --no-pager"
 
 systemctlEnableAndStart() {
   local ret
@@ -16678,27 +16678,27 @@ ensureKubeAddonManager() {
     {{/* Restart kubelet if kube-addon-manager is not Ready after 5 mins */}}
     systemctl_restart 3 5 30 kubelet
     {{/* Wait 5 more mins for kube-addon-manager to become Ready, and then return failure if not */}}
-    retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+    retrycmd 60 5 30 ${KUBECTL} wait --for=condition=Ready --timeout=5s po ${kam_pod} -n kube-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $K_LOG
   fi
 }
 
 ensureAddons() {
   local kam_pod=kube-addon-manager-${HOSTNAME}
 {{- if IsDashboardAddonEnabled}} {{/* Note: dashboard addon is deprecated */}}
-  retrycmd 120 5 30 $KUBECTL get namespace kubernetes-dashboard || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 30 $KUBECTL get namespace kubernetes-dashboard || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $K_LOG
 {{- end}}
 {{- if IsAzurePolicyAddonEnabled}}
-  retrycmd 120 5 30 $KUBECTL get namespace gatekeeper-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 30 $KUBECTL get namespace gatekeeper-system || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $K_LOG
 {{- end}}
 {{- if and (not HasCustomPodSecurityPolicy) IsPodSecurityPolicyAddonEnabled}}
-  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 30 $KUBECTL get podsecuritypolicy privileged restricted || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $K_LOG
 {{- end}}
   replaceAddonsInit
-  rm -Rf ${ADDONS_DIR}/init
+  rm -Rf ${AO_DIR}/init
   ensureKubeAddonManager
   {{/* Manually delete any kube-addon-manager pods that point to the init directory */}}
   for initPod in $(${KUBECTL} get pod ${kam_pod} -n kube-system -o json | jq -r '.items[] | select(.spec.containers[0].env[] | select(.value=="/etc/kubernetes/addons/init")) | select(.status.phase=="Running") .metadata.name'); do
-    retrycmd 120 5 30 ${KUBECTL} delete pod ${kam_pod} -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $GET_KUBELET_LOGS
+    retrycmd 120 5 30 ${KUBECTL} delete pod ${kam_pod} -n kube-system --force --grace-period 0 || exit_cse {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}} $K_LOG
   done
   {{if HasCiliumNetworkPolicy}}
   while [ ! -f /etc/cni/net.d/05-cilium.conf ]; do
@@ -16723,10 +16723,10 @@ ensureAddons() {
   {{end}}
 }
 replaceAddonsInit() {
-  wait_for_file 1200 1 $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  cp $ADDON_MANAGER_SPEC /tmp/kube-addon-manager.yaml || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
-  sed -i "s|${ADDONS_DIR}/init|${ADDONS_DIR}|g" /tmp/kube-addon-manager.yaml || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
-  mv /tmp/kube-addon-manager.yaml $ADDON_MANAGER_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  wait_for_file 1200 1 $AOM_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
+  cp $AOM_SPEC /tmp/kube-addon-manager.yaml || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  sed -i "s|${AO_DIR}/init|${AO_DIR}|g" /tmp/kube-addon-manager.yaml || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  mv /tmp/kube-addon-manager.yaml $AOM_SPEC || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
 }
 ensureLabelNodes() {
   wait_for_file 1200 1 /opt/azure/containers/label-nodes.sh || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
@@ -16774,11 +16774,11 @@ ensureK8sControlPlane() {
   if [ "$NO_OUTBOUND" = "true" ]; then
     return
   fi
-  retrycmd 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit_cse {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 25 $KUBECTL 2>/dev/null cluster-info || exit_cse {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}} $K_LOG
 }
 {{- if IsAzurePolicyAddonEnabled}}
 ensureLabelExclusionForAzurePolicyAddon() {
-  retrycmd 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager --overwrite 2>/dev/null || exit_cse {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}} $GET_KUBELET_LOGS
+  retrycmd 120 5 25 $KUBECTL label ns kube-system control-plane=controller-manager --overwrite 2>/dev/null || exit_cse {{GetCSEErrorCode "ERR_K8S_RUNNING_TIMEOUT"}} $K_LOG
 }
 {{end}}
 ensureEtcd() {
@@ -16829,7 +16829,7 @@ users:
 }
 {{- if IsClusterAutoscalerAddonEnabled}}
 configClusterAutoscalerAddon() {
-  local f=$ADDONS_DIR/cluster-autoscaler.yaml
+  local f=$AO_DIR/cluster-autoscaler.yaml
   wait_for_file 1200 1 $f || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
   sed -i "s|<clientID>|$(echo $SERVICE_PRINCIPAL_CLIENT_ID | base64)|g" $f
   sed -i "s|<clientSec>|$(echo $SERVICE_PRINCIPAL_CLIENT_SECRET | base64)|g" $f
@@ -16840,7 +16840,7 @@ configClusterAutoscalerAddon() {
 {{end}}
 {{- if IsAzurePolicyAddonEnabled}}
 configAzurePolicyAddon() {
-  sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $ADDONS_DIR/azure-policy-deployment.yaml
+  sed -i "s|<resourceId>|/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP|g" $AO_DIR/azure-policy-deployment.yaml
 }
 {{end}}
 
@@ -16855,7 +16855,7 @@ configAddons() {
   {{end}}
   {{- if and (not HasCustomPodSecurityPolicy) IsPodSecurityPolicyAddonEnabled}}
   wait_for_file 1200 1 $PSP_SPEC || exit {{GetCSEErrorCode "ERR_FILE_WATCH_TIMEOUT"}}
-  mkdir -p $ADDONS_DIR/init && cp $PSP_SPEC $ADDONS_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
+  mkdir -p $AO_DIR/init && cp $PSP_SPEC $AO_DIR/init/ || exit {{GetCSEErrorCode "ERR_ADDONS_START_FAIL"}}
   {{- end}}
 }
 {{- if and HasNSeriesSKU IsNvidiaDevicePluginAddonEnabled}}

--- a/test/e2e/engine/template.go
+++ b/test/e2e/engine/template.go
@@ -73,7 +73,7 @@ type Config struct {
 	CustomKubeControllerManagerImage string `envconfig:"CUSTOM_KUBE_CONTROLLER_MANAGER_IMAGE" default:""`
 	CustomKubeBinaryURL              string `envconfig:"CUSTOM_KUBE_BINARY_URL" default:""`
 	CustomWindowsPackageURL          string `envconfig:"CUSTOM_WINDOWS_PACKAGE_URL" default:""`
-	EnableTelemetry                  bool   `envconfig:"ENABLE_TELEMETRY" default:"true"`
+	EnableTelemetry                  bool   `envconfig:"ENABLE_TELEMETRY" default:"false"`
 	KubernetesImageBase              string `envconfig:"KUBERNETES_IMAGE_BASE" default:""`
 	KubernetesImageBaseType          string `envconfig:"KUBERNETES_IMAGE_BASE_TYPE" default:""`
 	LinuxContainerdURL               string `envconfig:"LINUX_CONTAINERD_URL"`

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -550,7 +550,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should validate DISA Ubuntu 20.04 STIG", func() {
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
-			} else if eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig {
+			} else if eng.ExpandedDefinition.Properties.FeatureFlags != nil && eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig {
 				nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 				STIGFilesValidateScript := "stig-validate.sh"
@@ -630,7 +630,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		It("should validate that every linux node has the right sshd config", func() {
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
-			} else if eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig {
+			} else if eng.ExpandedDefinition.Properties.FeatureFlags != nil && eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig {
 				Skip("Skip as feature flag EnforceUbuntu2004DisaStig is set")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
@@ -659,11 +659,13 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 		})
 
 		It("should validate password enforcement configuration", func() {
-			args := fmt.Sprintf("STIG=%t", eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig)
 			if cfg.BlockSSHPort {
 				Skip("SSH port is blocked")
 			} else if !eng.ExpandedDefinition.Properties.HasNonRegularPriorityScaleset() {
 				if eng.ExpandedDefinition.Properties.IsVHDDistroForAllNodes() {
+					enforceStig := eng.ExpandedDefinition.Properties.FeatureFlags != nil && eng.ExpandedDefinition.Properties.FeatureFlags.EnforceUbuntu2004DisaStig
+					args := fmt.Sprintf("STIG=%t", enforceStig)
+
 					nodes, err := node.GetReadyWithRetry(1*time.Second, cfg.Timeout)
 					Expect(err).NotTo(HaveOccurred())
 					pwQualityValidateScript := "pwquality-validate.sh"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Previously, deploying mixed clusters (linux + windows nodes) with azuredisk-csi-driver addon hit custom data too long error: 
`Custom data in OSProfile must be in Base64 encoding and with a maximum length of 87380 characters.`

- This PR shortens variable names in cloud init scripts, reducing custom data length. 
- ci: Test suites previously set EnableTelemetry to true by default, which caused the CSE to be longer. This PR sets EnableTelemetry to false by default.
- ci: Fix featureflag nil pointers now that the EnableTelemetry feature flag is no longer set by default.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
