### PR TITLE
fix: enableUnattendedUpgrades not honored

### DIFF
--- a/pkg/api/converterfromapi.go
+++ b/pkg/api/converterfromapi.go
@@ -175,6 +175,7 @@ func convertLinuxProfileToVLabs(obj *LinuxProfile, vlabsProfile *vlabs.LinuxProf
 		vlabsProfile.CustomNodesDNS.DNSServer = obj.CustomNodesDNS.DNSServer
 	}
 	vlabsProfile.RunUnattendedUpgradesOnBootstrap = obj.RunUnattendedUpgradesOnBootstrap
+	vlabsProfile.EnableUnattendedUpgrades = obj.EnableUnattendedUpgrades
 	vlabsProfile.Eth0MTU = obj.Eth0MTU
 }
 

--- a/pkg/api/converterfromapi_test.go
+++ b/pkg/api/converterfromapi_test.go
@@ -925,3 +925,85 @@ func TestConvertComponentsToVlabs(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertLinuxProfileToVlabs(t *testing.T) {
+	ssh := struct {
+		PublicKeys []vlabs.PublicKey `json:"publicKeys" validate:"required,min=1"`
+	}{
+		PublicKeys: []vlabs.PublicKey{},
+	}
+
+	cases := []struct {
+		name     string
+		w        LinuxProfile
+		expected vlabs.LinuxProfile
+	}{
+		{
+			name: "unattended upgrades on bootstrap",
+			w: LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+			expected: vlabs.LinuxProfile{
+				Secrets:                          []vlabs.KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+			expected: vlabs.LinuxProfile{
+				Secrets:                          []vlabs.KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+			expected: vlabs.LinuxProfile{
+				Secrets:                          []vlabs.KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+			expected: vlabs.LinuxProfile{
+				Secrets:                          []vlabs.KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actual := vlabs.LinuxProfile{}
+			convertLinuxProfileToVLabs(&c.w, &actual)
+
+			diff := cmp.Diff(actual, c.expected)
+
+			if diff != "" {
+				t.Errorf("unexpected diff testing convertLinuxProfileToVLabs: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/api/convertertoapi.go
+++ b/pkg/api/convertertoapi.go
@@ -171,6 +171,7 @@ func convertVLabsLinuxProfile(vlabs *vlabs.LinuxProfile, api *LinuxProfile) {
 		api.CustomNodesDNS.DNSServer = vlabs.CustomNodesDNS.DNSServer
 	}
 	api.RunUnattendedUpgradesOnBootstrap = vlabs.RunUnattendedUpgradesOnBootstrap
+	api.EnableUnattendedUpgrades = vlabs.EnableUnattendedUpgrades
 	api.Eth0MTU = vlabs.Eth0MTU
 }
 

--- a/pkg/api/convertertoapi_test.go
+++ b/pkg/api/convertertoapi_test.go
@@ -1169,3 +1169,84 @@ func TestConvertComponentsToAPI(t *testing.T) {
 		}
 	}
 }
+
+func TestConvertVLabsLinuxProfile(t *testing.T) {
+	ssh := struct {
+		PublicKeys []PublicKey `json:"publicKeys"`
+	}{
+		PublicKeys: []PublicKey{},
+	}
+
+	cases := []struct {
+		name     string
+		w        vlabs.LinuxProfile
+		expected LinuxProfile
+	}{
+		{
+			name: "unattended upgrades on bootstrap",
+			w: vlabs.LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+			expected: LinuxProfile{
+				Secrets:                          []KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: vlabs.LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+			expected: LinuxProfile{
+				Secrets:                          []KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: vlabs.LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+			expected: LinuxProfile{
+				Secrets:                          []KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(true),
+				EnableUnattendedUpgrades:         to.BoolPtr(false),
+			},
+		},
+		{
+			name: "unattended upgrades on bootstrap",
+			w: vlabs.LinuxProfile{
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+			expected: LinuxProfile{
+				Secrets:                          []KeyVaultSecrets{},
+				SSH:                              ssh,
+				RunUnattendedUpgradesOnBootstrap: to.BoolPtr(false),
+				EnableUnattendedUpgrades:         to.BoolPtr(true),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			actual := LinuxProfile{}
+			convertVLabsLinuxProfile(&c.w, &actual)
+
+			diff := cmp.Diff(actual, c.expected)
+			if diff != "" {
+				t.Errorf("unexpected diff testing convertVLabsLinuxProfile: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Reason for Change**:

`linuxProfile.enableUnattendedUpgrades` is not honored nor persisted in the output API Model.

By default, `enableUnattendedUpgrades` is set to `true`. In practice, this bug affected those users that set the value to `false`. In that case, the `false` value was ignored and unattended upgrades were not disabled.

This fix should effectively disable unattended upgrades for those customers that would like to disable it (air-gapped environments most likely).

**Issue Fixed**:

Fixes #44

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes