### PR TITLE
fix: persist runUnattendedUpgradesOnBootstrap even if not set by input API model

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -223,6 +223,8 @@ const (
 	StandardVMType = "standard"
 	// DefaultRunUnattendedUpgradesOnBootstrap sets the default configuration for running a blocking unattended-upgrade on Linux VMs as part of CSE
 	DefaultRunUnattendedUpgradesOnBootstrap = true
+	// DefaultRunUnattendedUpgradesOnBootstrapAzureStack sets the default configuration for running a blocking unattended-upgrade on Linux VMs as part of CSE for Azure Stack Hub
+	DefaultRunUnattendedUpgradesOnBootstrapAzureStack = false
 	// DefaultEnableUnattendedUpgrades sets the default configuration for running unattended-upgrade on a regular schedule in the background
 	DefaultEnableUnattendedUpgrades = true
 	// DefaultEnableUnattendedUpgradesAzureStack sets the default configuration for running unattended-upgrade on a regular schedule in the background for Azure Stack Hub

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -723,8 +723,12 @@ func (p *Properties) setMasterProfileDefaults() {
 }
 
 func (p *Properties) setLinuxProfileDefaults() {
-	if !p.IsAzureStackCloud() && p.LinuxProfile.RunUnattendedUpgradesOnBootstrap == nil {
-		p.LinuxProfile.RunUnattendedUpgradesOnBootstrap = to.BoolPtr(DefaultRunUnattendedUpgradesOnBootstrap)
+	if p.LinuxProfile.RunUnattendedUpgradesOnBootstrap == nil {
+		if p.IsAzureStackCloud() {
+			p.LinuxProfile.RunUnattendedUpgradesOnBootstrap = to.BoolPtr(DefaultRunUnattendedUpgradesOnBootstrapAzureStack)
+		} else {
+			p.LinuxProfile.RunUnattendedUpgradesOnBootstrap = to.BoolPtr(DefaultRunUnattendedUpgradesOnBootstrap)
+		}
 	}
 	if p.LinuxProfile.EnableUnattendedUpgrades == nil {
 		if p.IsAzureStackCloud() {


### PR DESCRIPTION
**Reason for Change**:

`runUnattendedUpgradesOnBootstrap` is persisted in the output API Model only if a value is set explicitly.

This PR ensures that `runUnattendedUpgradesOnBootstrap` is always persisted.

The default behavior is not altered.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
