### PR TITLE
security: incorrect conversion between integer types

### DIFF
--- a/pkg/engine/virtualmachines.go
+++ b/pkg/engine/virtualmachines.go
@@ -162,7 +162,7 @@ func CreateMasterVM(cs *api.ContainerService) VirtualMachineARM {
 
 	storageProfile := &compute.StorageProfile{}
 	imageRef := cs.Properties.MasterProfile.ImageRef
-	etcdSizeGB, _ := strconv.Atoi(kubernetesConfig.EtcdDiskSizeGB)
+	etcdSizeGB, _ := strconv.ParseInt(kubernetesConfig.EtcdDiskSizeGB, 10, 32)
 	if !cs.Properties.MasterProfile.HasCosmosEtcd() {
 		dataDisk := compute.DataDisk{
 			CreateOption: compute.DiskCreateOptionTypesEmpty,

--- a/pkg/engine/virtualmachinescalesets.go
+++ b/pkg/engine/virtualmachinescalesets.go
@@ -250,7 +250,7 @@ func CreateMasterVMSS(cs *api.ContainerService) VirtualMachineScaleSetARM {
 
 	storageProfile := compute.VirtualMachineScaleSetStorageProfile{}
 	imageRef := masterProfile.ImageRef
-	etcdSizeGB, _ := strconv.Atoi(k8sConfig.EtcdDiskSizeGB)
+	etcdSizeGB, _ := strconv.ParseInt(k8sConfig.EtcdDiskSizeGB, 10, 32)
 	dataDisk := compute.VirtualMachineScaleSetDataDisk{
 		CreateOption: compute.DiskCreateOptionTypesEmpty,
 		DiskSizeGB:   to.Int32Ptr(int32(etcdSizeGB)),


### PR DESCRIPTION
**Reason for Change**:

Fix 2 instances of `codeql` warning `"Incorrect conversion between integer types"`.

**Issue Fixed**:

Fixes #146