### PR TITLE
chore: upgrade azure network policy manager to v1.4.32

### DIFF
--- a/parts/k8s/addons/azure-network-policy.yaml
+++ b/parts/k8s/addons/azure-network-policy.yaml
@@ -71,12 +71,17 @@ spec:
         k8s-app: azure-npm
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        azure.npm/scrapeable: ''
 {{- if IsKubernetesVersionGe "1.17.0"}}
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
 {{- end}}
     spec:
       priorityClassName: system-node-critical
       tolerations:
+      - operator: "Exists"
+        effect: NoExecute
+      - operator: "Exists"
+        effect: NoSchedule
       - key: CriticalAddonsOnly
         operator: Exists
       nodeSelector:
@@ -99,6 +104,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: NPM_CONFIG
+              value: /etc/azure-npm/azure-npm.json
           volumeMounts:
           - name: xtables-lock
             mountPath: /run/xtables.lock
@@ -106,6 +113,8 @@ spec:
             mountPath: /var/log
           - name: protocols
             mountPath: /etc/protocols
+          - name: azure-npm-config
+            mountPath: /etc/azure-npm
       hostNetwork: true
       volumes:
       - name: log
@@ -120,4 +129,49 @@ spec:
         hostPath:
           path: /etc/protocols
           type: File
+      - name: azure-npm-config
+        configMap:
+          name: azure-npm-config
       serviceAccountName: azure-npm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: npm-metrics-cluster-service
+  namespace: kube-system
+  labels:
+    app: npm-metrics
+    addonmanager.kubernetes.io/mode: {{GetMode}}
+spec:
+  selector:
+    k8s-app: azure-npm
+  ports:
+    - port: 9000
+      targetPort: 10091
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-npm-config
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: {{GetMode}}
+data:
+  azure-npm.json: |
+    {
+        "ResyncPeriodInMinutes":       15,
+        "ListeningPort":               10091,
+        "ListeningAddress":            "0.0.0.0",
+        "ApplyMaxBatches":             100,
+        "ApplyIntervalInMilliseconds": 500,
+        "MaxBatchedACLsPerPod":        30,
+        "Toggles": {
+            "EnablePrometheusMetrics": true,
+            "EnablePprof":             true,
+            "EnableHTTPDebugAPI":      true,
+            "EnableV2NPM":             true,
+            "PlaceAzureChainFirst":    true,
+            "ApplyIPSetsOnNeed":       false,
+            "ApplyInBackground":       true
+        }
+    }

--- a/pkg/api/k8s_versions.go
+++ b/pkg/api/k8s_versions.go
@@ -27,7 +27,7 @@ const (
 	antreaAgentImageReference                                = antreaControllerImageReference
 	antreaOVSImageReference                                  = antreaControllerImageReference
 	antreaInstallCNIImageReference                           = antreaControllerImageReference
-	azureNPMContainerImageReference                   string = "mcr.microsoft.com/containernetworking/azure-npm:v1.2.2_hotfix"
+	azureNPMContainerImageReference                   string = "mcr.microsoft.com/containernetworking/azure-npm:v1.4.32"
 	aadPodIdentityNMIImageReference                   string = "mcr.microsoft.com/k8s/aad-pod-identity/nmi:1.6.1"
 	aadPodIdentityMICImageReference                   string = "mcr.microsoft.com/k8s/aad-pod-identity/mic:1.6.1"
 	azurePolicyImageReference                         string = "mcr.microsoft.com/azure-policy/policy-kubernetes-addon-prod:prod_20201023.1"

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -165,7 +165,7 @@ done
 
 AZURE_CNIIMAGEBASE="mcr.microsoft.com/containernetworking"
 AZURE_NPM_VERSIONS="
-1.2.2_hotfix
+1.4.32
 "
 for AZURE_NPM_VERSION in ${AZURE_NPM_VERSIONS}; do
     CONTAINER_IMAGE="${AZURE_CNIIMAGEBASE}/azure-npm:v${AZURE_NPM_VERSION}"


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
https://github.com/Azure/azure-container-networking/releases/tag/v1.4.32

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
With this version upgrade of azure network policy manager component, pods can now establish egress network connections when they are in a state of terminating (During the default 30 second grace period).

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
