### PR TITLE
fix: stop collecting docker engine logs for Windows nodes

### DIFF
--- a/cmd/get_logs.go
+++ b/cmd/get_logs.go
@@ -419,7 +419,7 @@ func collectLogsScript(f *ssh.RemoteFile, os api.OSType, isAzureStack bool) stri
 		}
 		return fmt.Sprintf("sudo -E bash -c %s", f.Path)
 	case api.Windows:
-		return fmt.Sprintf("powershell -command \"iex %s | Where-Object { $_.extension -eq '.zip' } | Copy-Item -Destination $env:temp\\$env:computername.zip\"", f.Path)
+		return fmt.Sprintf("powershell -command \"iex %s; ls . | Where-Object { $_.extension -eq '.zip' } | sort LastWriteTime -Descending | Select -First 1 | Copy-Item -Destination $env:temp\\$env:computername.zip\"", f.Path)
 	default:
 		return ""
 	}

--- a/scripts/collect-windows-logs.ps1
+++ b/scripts/collect-windows-logs.ps1
@@ -61,7 +61,7 @@ if (Test-Path $containerd) {
 }
 
 Write-Host "Exporting ETW events to CSV files"
-$scm = Get-WinEvent -FilterHashtable @{logname = 'System'; ProviderName = 'Service Control Manager' } | Where-Object { $_.Message -Like "*docker*" -or $_.Message -Like "*kub*" } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
+$scm = Get-WinEvent -FilterHashtable @{logname = 'System'; ProviderName = 'Service Control Manager' } | Where-Object { $_.Message -Like "*kub*" } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
 # 2004 = resource exhaustion, other 5 events related to reboots
 $reboots = Get-WinEvent -ErrorAction Ignore -FilterHashtable @{logname = 'System'; id = 1074, 1076, 2004, 6005, 6006, 6008 } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
 $crashes = Get-WinEvent -ErrorAction Ignore -FilterHashtable @{logname = 'Application'; ProviderName = 'Windows Error Reporting' } | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message
@@ -69,8 +69,6 @@ $scm + $reboots + $crashes | Sort-Object TimeCreated | Export-CSV -Path "$ENV:TE
 $paths += "$ENV:TEMP\\$($timeStamp)_services.csv"
 Get-WinEvent -LogName Microsoft-Windows-Hyper-V-Compute-Operational | Select-Object -Property TimeCreated, Id, LevelDisplayName, Message | Sort-Object TimeCreated | Export-Csv -Path "$ENV:TEMP\\$($timeStamp)_hyper-v-compute-operational.csv"
 $paths += "$ENV:TEMP\\$($timeStamp)_hyper-v-compute-operational.csv"
-get-eventlog -LogName Application -Source Docker | Select-Object Index, TimeGenerated, EntryType, Message | Sort-Object Index | Export-CSV -Path "$ENV:TEMP\\$($timeStamp)_docker.csv"
-$paths += "$ENV:TEMP\\$($timeStamp)_docker.csv"
 Get-CimInstance win32_pagefileusage | Format-List * | Out-File -Append "$ENV:TEMP\\$($timeStamp)_pagefile.txt"
 Get-CimInstance win32_computersystem | Format-List AutomaticManagedPagefile | Out-File -Append "$ENV:TEMP\\$($timeStamp)_pagefile.txt"
 $paths += "$ENV:TEMP\\$($timeStamp)_pagefile.txt"
@@ -99,7 +97,7 @@ else {
   Write-Host "Containerd hyperv logs not avalaible"
 }
 
-# log containerd containers (this is done for docker via networking collectlogs.ps1)
+# log containerd containers
 $res = Get-Command ctr.exe -ErrorAction SilentlyContinue
 if ($res)
 { 

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -289,7 +289,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
       --linux-script ./scripts/collect-logs.sh \
       --windows-script ./scripts/collect-windows-logs.ps1
 
-      for logfile in _output/$RESOURCE_GROUP/_logs/*.zip; do
+      for logfile in _output/${RESOURCE_GROUP}/_logs/*.zip; do
         if [ -z "$(cat ${logfile})" ]; then
           echo "File ${logfile} is empty"
           exit 1

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -288,6 +288,13 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
       --linux-ssh-private-key _output/$RESOURCE_GROUP-ssh \
       --linux-script ./scripts/collect-logs.sh \
       --windows-script ./scripts/collect-windows-logs.ps1
+
+      for logfile in _output/$RESOURCE_GROUP/_logs/*.zip; do
+        if [ -z "$(cat ${logfile})" ]; then
+          echo "File ${logfile} is empty"
+          exit 1
+        fi
+      done
   fi
 
   if [ $(( RANDOM % 4 )) -eq 3 ]; then

--- a/test/e2e/cluster.sh
+++ b/test/e2e/cluster.sh
@@ -289,7 +289,7 @@ if [ "${UPGRADE_CLUSTER}" = "true" ] || [ "${SCALE_CLUSTER}" = "true" ] || [ -n 
       --linux-script ./scripts/collect-logs.sh \
       --windows-script ./scripts/collect-windows-logs.ps1
 
-      for logfile in _output/${RESOURCE_GROUP}/_logs/*.zip; do
+      for logfile in "_output/${RESOURCE_GROUP}/_logs"/*.zip; do
         if [ -z "$(cat ${logfile})" ]; then
           echo "File ${logfile} is empty"
           exit 1


### PR DESCRIPTION
**Reason for Change**:

Removing docker logs from the Windows log collection script.

**Issue Fixed**:

Fixes #150
