### PR TITLE
fix: update WindowsContainerdURL during upgrade and scale

### DIFF
--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -249,7 +249,7 @@ func (cs *ContainerService) setOrchestratorDefaults(isUpgrade, isScale bool) {
 				o.KubernetesConfig.ContainerdVersion = DefaultContainerdVersion
 			}
 
-			if o.KubernetesConfig.WindowsContainerdURL == "" {
+			if o.KubernetesConfig.WindowsContainerdURL == "" || isUpdate {
 				o.KubernetesConfig.WindowsContainerdURL = DefaultWindowsContainerdURL
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
During upgrade and scale commands, WindowsContainerdURL was not being updated. With this change, updating WindowsContainerdURL will follow the same pattern as updating containerd version. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes upgrade and scale when WindowsContainerdURL has changed.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
