### PR TITLE
chore: upgrade Windows csi-proxy to v1.1.3

### DIFF
--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -478,7 +478,7 @@ const (
 // WindowsProfile defaults
 // TODO: Move other values defined in WindowsProfiles (like DefaultWindowsSSHEnabled) here.
 const (
-	DefaultWindowsCsiProxyVersion                   = "v0.2.2"
+	DefaultWindowsCsiProxyVersion                   = "v1.1.3"
 	DefaultWindowsProvisioningScriptsPackageVersion = "v0.0.16"
 )
 

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -53,7 +53,9 @@ function Get-ContainerImages {
                 "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.25.9",
                 "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:v1.26.10",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.10.0",
+                "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.10.0-windows-hp",
                 "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.26.5",
+                "mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.26.5-windows-hp",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.6.2",
                 "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0",
@@ -124,7 +126,7 @@ function Get-FilesToCacheOnVHD {
             $global:containerdPackageUrl
         );
         "c:\akse-cache\csi-proxy\"    = @(
-            "https://kubernetesartifacts.azureedge.net/csi-proxy/v0.2.2/binaries/csi-proxy-v0.2.2.tar.gz"
+            "https://kubernetesartifacts.azureedge.net/csi-proxy/v1.1.3/binaries/csi-proxy-v1.1.3.tar.gz"
         );
         "c:\akse-cache\win-k8s\"      = @(
             "https://kubernetesartifacts.azureedge.net/kubernetes/v1.25.13/windowszip/v1.25.13-1int.zip",


### PR DESCRIPTION
**Reason for Change**:

Also adding extra images to simplify the transition to use HostProcesses instead of `csi-proxy`:

- `mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.10.0-windows-hp` 
- `mcr.microsoft.com/oss/kubernetes-csi/azuredisk-csi:v1.26.5-windows-hp`

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
