### PR TITLE
test: e2e validates Windows HostProcess pods

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -856,6 +856,23 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 			}
 		})
 
+		It("should be able to schedule a HostProcess pod to a Windows node", func() {
+			if eng.HasWindowsAgents() {
+				name, ns := "windows-hostprocess", "default"
+				yamlPath := filepath.Join(WorkloadDir, fmt.Sprintf("%s.yaml", name))
+				By("deleting existing HostProcess pods")
+				pod.DeleteAllByLabel("test", name, ns)
+				By("deploying new HostProcess pod")
+				_, err := pod.CreatePodFromFile(yamlPath, name, ns, 1*time.Second, 20*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				running, err := pod.WaitOnSuccesses(name, ns, 4, false, 4*time.Second, 30*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(running).To(Equal(true))
+			} else {
+				Skip("no Windows nodes")
+			}
+		})
+
 		It("should have core kube-system addons running the correct version", func() {
 			if eng.ExpandedDefinition.Properties.OrchestratorProfile.KubernetesConfig.CustomKubeProxyImage == "" {
 				By(fmt.Sprintf("Ensuring that the %s addon image matches orchestrator version", common.KubeProxyAddonName))

--- a/test/e2e/kubernetes/pod/pod.go
+++ b/test/e2e/kubernetes/pod/pod.go
@@ -690,6 +690,13 @@ func GetAllByPrefix(prefix, namespace string) ([]Pod, error) {
 	return pods, nil
 }
 
+func DeleteAllByLabel(labelKey, labelVal, namespace string) {
+	pods, _ := GetAllByLabel(labelKey, labelVal, namespace)
+	for _, p := range pods {
+		p.Delete(util.DefaultDeleteRetries)
+	}
+}
+
 // GetAllRunningByLabelAsync wraps GetAllRunningByLabel with a struct response for goroutine + channel usage
 func GetAllRunningByLabelAsync(labelKey, labelVal, namespace string) GetPodsResult {
 	pods, err := GetAllRunningByLabel(labelKey, labelVal, namespace)

--- a/test/e2e/kubernetes/workloads/windows-hostprocess.yaml
+++ b/test/e2e/kubernetes/workloads/windows-hostprocess.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windows-hostprocess
+  labels:
+    test: windows-hostprocess
+spec: 
+  containers:
+    - name: is-admin-role
+      image: mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
+      command:
+        - powershell.exe
+        - "-command"
+        - 'if (([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator") -eq $True) { Start-Sleep -Seconds 2147483 } else { exit 1 };'
+  securityContext:
+    runAsNonRoot: false
+    windowsOptions:
+      hostProcess: true
+      runAsUserName: "NT AUTHORITY\\SYSTEM"
+  hostNetwork: true
+  nodeSelector:
+    "kubernetes.io/os": windows

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -59,7 +59,8 @@ function Get-ContainerImages {
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.4.0",
                 "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.6.2",
                 "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.5.0",
-                "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.8.0")
+                "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.8.0",
+                "mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0")
         }
         '2004' {
             $imagesToPull = @(


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:

Adding a e2e test to validate Windows HostProcess pods.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
