### PR TITLE
chore: remove invalid k8s v1.28 flags and feature gates

### DIFF
--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -234,6 +234,40 @@ func (cs *ContainerService) overrideAPIServerConfig() {
 		// Reference: https://github.com/kubernetes/kubernetes/pull/114410
 		invalidFeatureGates = append(invalidFeatureGates, "CSIInlineVolume", "CSIMigration", "CSIMigrationAzureDisk", "DaemonSetUpdateSurge", "EphemeralContainers", "IdentifyPodOS", "LocalStorageCapacityIsolation", "NetworkPolicyEndPort", "StatefulSetMinReadySeconds")
 	}
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.28.0") {
+		// Remove --feature-gate AdvancedAuditing,DisableAcceleratorUsageMetrics,DryRun,PodSecurity starting with 1.28
+		invalidFeatureGates = append(invalidFeatureGates, "AdvancedAuditing", "DisableAcceleratorUsageMetrics", "DryRun", "PodSecurity")
+
+		invalidFeatureGates = append(invalidFeatureGates, "NetworkPolicyStatus", "PodHasNetworkCondition", "UserNamespacesStatelessPodsSupport")
+
+		// Remove --feature-gate CSIMigrationGCE starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117055
+		invalidFeatureGates = append(invalidFeatureGates, "CSIMigrationGCE")
+
+		// Remove --feature-gate CSIStorageCapacity starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/118018
+		invalidFeatureGates = append(invalidFeatureGates, "CSIStorageCapacity")
+
+		// Remove --feature-gate DelegateFSGroupToCSIDriver starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117655
+		invalidFeatureGates = append(invalidFeatureGates, "DelegateFSGroupToCSIDriver")
+
+		// Remove --feature-gate DevicePlugins starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117656
+		invalidFeatureGates = append(invalidFeatureGates, "DevicePlugins")
+
+		// Remove --feature-gate KubeletCredentialProviders starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/116901
+		invalidFeatureGates = append(invalidFeatureGates, "KubeletCredentialProviders")
+
+		// Remove --feature-gate MixedProtocolLBService, ServiceInternalTrafficPolicy, ServiceIPStaticSubrange, EndpointSliceTerminatingCondition  starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117237
+		invalidFeatureGates = append(invalidFeatureGates, "MixedProtocolLBService", "ServiceInternalTrafficPolicy", "ServiceIPStaticSubrange", "EndpointSliceTerminatingCondition")
+
+		// Remove --feature-gate WindowsHostProcessContainers starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117570
+		invalidFeatureGates = append(invalidFeatureGates, "WindowsHostProcessContainers")
+	}
 	removeInvalidFeatureGates(o.KubernetesConfig.APIServerConfig, invalidFeatureGates)
 
 	if common.ShouldDisablePodSecurityPolicyAddon(o.OrchestratorVersion) {

--- a/pkg/api/defaults-apiserver_test.go
+++ b/pkg/api/defaults-apiserver_test.go
@@ -673,6 +673,33 @@ func TestAPIServerFeatureGates(t *testing.T) {
 		t.Fatalf("got unexpected '--feature-gates' API server config value for \"--feature-gates\": %s for k8s v%s",
 			a["--feature-gates"], "1.26.0")
 	}
+
+	// test user-overrides, removal of feature gates for k8s versions >= 1.28
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.28.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = make(map[string]string)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	featuregate128 := "AdvancedAuditing=true,CSIMigrationGCE=true,CSIStorageCapacity=true,DelegateFSGroupToCSIDriver=true,DevicePlugins=true,DisableAcceleratorUsageMetrics=true,DryRun=true,EndpointSliceTerminatingCondition=true,KubeletCredentialProviders=true,MixedProtocolLBService=true,NetworkPolicyStatus=true,PodHasNetworkCondition=true,PodSecurity=true,ServiceIPStaticSubrange=true,ServiceInternalTrafficPolicy=true,UserNamespacesStatelessPodsSupport=true,WindowsHostProcessContainers=true"
+	a["--feature-gates"] = featuregate128
+	featuregate128Sanitized := ""
+	cs.setAPIServerConfig()
+	if a["--feature-gates"] != featuregate128Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n API server config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.28.0", featuregate128, a["--feature-gates"], featuregate128Sanitized)
+	}
+
+	// test user-overrides, no removal of feature gates for k8s versions < 1.27
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.27.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = make(map[string]string)
+	a = cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig
+	a["--feature-gates"] = featuregate128
+	featuregate127Sanitized := featuregate128
+	cs.setAPIServerConfig()
+	if a["--feature-gates"] != featuregate127Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n API server config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.27.0", featuregate128, a["--feature-gates"], featuregate127Sanitized)
+	}
 }
 
 func TestAPIServerInsecureFlag(t *testing.T) {

--- a/pkg/api/defaults-cloud-controller-manager.go
+++ b/pkg/api/defaults-cloud-controller-manager.go
@@ -80,6 +80,42 @@ func (cs *ContainerService) setCloudControllerManagerConfig() {
 		// Reference: https://github.com/kubernetes/kubernetes/pull/114410
 		invalidFeatureGates = append(invalidFeatureGates, "CSIInlineVolume", "CSIMigration", "CSIMigrationAzureDisk", "DaemonSetUpdateSurge", "EphemeralContainers", "IdentifyPodOS", "LocalStorageCapacityIsolation", "NetworkPolicyEndPort", "StatefulSetMinReadySeconds")
 	}
+
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.28.0") {
+		// Remove --feature-gate AdvancedAuditing starting with 1.28
+		invalidFeatureGates = append(invalidFeatureGates, "AdvancedAuditing", "DisableAcceleratorUsageMetrics", "DryRun", "PodSecurity")
+
+		invalidFeatureGates = append(invalidFeatureGates, "NetworkPolicyStatus", "PodHasNetworkCondition", "UserNamespacesStatelessPodsSupport")
+
+		// Remove --feature-gate CSIMigrationGCE starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117055
+		invalidFeatureGates = append(invalidFeatureGates, "CSIMigrationGCE")
+
+		// Remove --feature-gate CSIStorageCapacity starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/118018
+		invalidFeatureGates = append(invalidFeatureGates, "CSIStorageCapacity")
+
+		// Remove --feature-gate DelegateFSGroupToCSIDriver starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117655
+		invalidFeatureGates = append(invalidFeatureGates, "DelegateFSGroupToCSIDriver")
+
+		// Remove --feature-gate DevicePlugins starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117656
+		invalidFeatureGates = append(invalidFeatureGates, "DevicePlugins")
+
+		// Remove --feature-gate KubeletCredentialProviders starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/116901
+		invalidFeatureGates = append(invalidFeatureGates, "KubeletCredentialProviders")
+
+		// Remove --feature-gate MixedProtocolLBService, ServiceInternalTrafficPolicy, ServiceIPStaticSubrange, EndpointSliceTerminatingCondition  starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117237
+		invalidFeatureGates = append(invalidFeatureGates, "MixedProtocolLBService", "ServiceInternalTrafficPolicy", "ServiceIPStaticSubrange", "EndpointSliceTerminatingCondition")
+
+		// Remove --feature-gate WindowsHostProcessContainers starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117570
+		invalidFeatureGates = append(invalidFeatureGates, "WindowsHostProcessContainers")
+	}
+
 	removeInvalidFeatureGates(o.KubernetesConfig.CloudControllerManagerConfig, invalidFeatureGates)
 
 	// TODO add RBAC support

--- a/pkg/api/defaults-cloud-controller-manager_test.go
+++ b/pkg/api/defaults-cloud-controller-manager_test.go
@@ -97,4 +97,31 @@ func TestCloudControllerManagerFeatureGates(t *testing.T) {
 		t.Fatalf("got unexpected '--feature-gates' API server config value for \"--feature-gates\": %s for k8s v%s",
 			ccm["--feature-gates"], "1.26.0")
 	}
+
+	// test user-overrides, removal of feature gates for k8s versions >= 1.28
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.28.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig = make(map[string]string)
+	ccm = cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	featuregate128 := "AdvancedAuditing=true,CSIMigrationGCE=true,CSIStorageCapacity=true,DelegateFSGroupToCSIDriver=true,DevicePlugins=true,DisableAcceleratorUsageMetrics=true,DryRun=true,EndpointSliceTerminatingCondition=true,KubeletCredentialProviders=true,MixedProtocolLBService=true,NetworkPolicyStatus=true,PodHasNetworkCondition=true,PodSecurity=true,ServiceIPStaticSubrange=true,ServiceInternalTrafficPolicy=true,UserNamespacesStatelessPodsSupport=true,WindowsHostProcessContainers=true"
+	ccm["--feature-gates"] = featuregate128
+	featuregate128Sanitized := ""
+	cs.setCloudControllerManagerConfig()
+	if ccm["--feature-gates"] != featuregate128Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n controller manager config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.28.0", featuregate128, ccm["--feature-gates"], featuregate128Sanitized)
+	}
+
+	// test user-overrides, no removal of feature gates for k8s versions < 1.27
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.27.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig = make(map[string]string)
+	ccm = cs.Properties.OrchestratorProfile.KubernetesConfig.CloudControllerManagerConfig
+	ccm["--feature-gates"] = featuregate128
+	featuregate127Sanitized := featuregate128
+	cs.setCloudControllerManagerConfig()
+	if ccm["--feature-gates"] != featuregate127Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n controller manager config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.27.0", featuregate128, ccm["--feature-gates"], featuregate127Sanitized)
+	}
 }

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -154,5 +154,40 @@ func (cs *ContainerService) setControllerManagerConfig() {
 		invalidFeatureGates = append(invalidFeatureGates, "LegacyServiceAccountTokenNoAutoGeneration")
 
 	}
+
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.28.0") {
+		// Remove --feature-gate AdvancedAuditing starting with 1.28
+		invalidFeatureGates = append(invalidFeatureGates, "AdvancedAuditing", "DisableAcceleratorUsageMetrics", "DryRun", "PodSecurity")
+
+		invalidFeatureGates = append(invalidFeatureGates, "NetworkPolicyStatus", "PodHasNetworkCondition", "UserNamespacesStatelessPodsSupport")
+
+		// Remove --feature-gate CSIMigrationGCE starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117055
+		invalidFeatureGates = append(invalidFeatureGates, "CSIMigrationGCE")
+
+		// Remove --feature-gate CSIStorageCapacity starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/118018
+		invalidFeatureGates = append(invalidFeatureGates, "CSIStorageCapacity")
+
+		// Remove --feature-gate DelegateFSGroupToCSIDriver starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117655
+		invalidFeatureGates = append(invalidFeatureGates, "DelegateFSGroupToCSIDriver")
+
+		// Remove --feature-gate DevicePlugins starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117656
+		invalidFeatureGates = append(invalidFeatureGates, "DevicePlugins")
+
+		// Remove --feature-gate KubeletCredentialProviders starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/116901
+		invalidFeatureGates = append(invalidFeatureGates, "KubeletCredentialProviders")
+
+		// Remove --feature-gate MixedProtocolLBService, ServiceInternalTrafficPolicy, ServiceIPStaticSubrange, EndpointSliceTerminatingCondition  starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117237
+		invalidFeatureGates = append(invalidFeatureGates, "MixedProtocolLBService", "ServiceInternalTrafficPolicy", "ServiceIPStaticSubrange", "EndpointSliceTerminatingCondition")
+
+		// Remove --feature-gate WindowsHostProcessContainers starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117570
+		invalidFeatureGates = append(invalidFeatureGates, "WindowsHostProcessContainers")
+	}
 	removeInvalidFeatureGates(o.KubernetesConfig.ControllerManagerConfig, invalidFeatureGates)
 }

--- a/pkg/api/defaults-kubelet.go
+++ b/pkg/api/defaults-kubelet.go
@@ -202,6 +202,41 @@ func (cs *ContainerService) setKubeletConfig(isUpgrade bool) {
 		// Reference: https://github.com/kubernetes/kubernetes/pull/114410
 		invalidFeatureGates = append(invalidFeatureGates, "CSIInlineVolume", "CSIMigration", "CSIMigrationAzureDisk", "DaemonSetUpdateSurge", "EphemeralContainers", "IdentifyPodOS", "LocalStorageCapacityIsolation", "NetworkPolicyEndPort", "StatefulSetMinReadySeconds")
 	}
+
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.28.0") {
+		// Remove --feature-gate AdvancedAuditing starting with 1.28
+		invalidFeatureGates = append(invalidFeatureGates, "AdvancedAuditing", "DisableAcceleratorUsageMetrics", "DryRun", "PodSecurity")
+
+		invalidFeatureGates = append(invalidFeatureGates, "NetworkPolicyStatus", "PodHasNetworkCondition", "UserNamespacesStatelessPodsSupport")
+
+		// Remove --feature-gate CSIMigrationGCE starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117055
+		invalidFeatureGates = append(invalidFeatureGates, "CSIMigrationGCE")
+
+		// Remove --feature-gate CSIStorageCapacity starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/118018
+		invalidFeatureGates = append(invalidFeatureGates, "CSIStorageCapacity")
+
+		// Remove --feature-gate DelegateFSGroupToCSIDriver starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117655
+		invalidFeatureGates = append(invalidFeatureGates, "DelegateFSGroupToCSIDriver")
+
+		// Remove --feature-gate DevicePlugins starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117656
+		invalidFeatureGates = append(invalidFeatureGates, "DevicePlugins")
+
+		// Remove --feature-gate KubeletCredentialProviders starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/116901
+		invalidFeatureGates = append(invalidFeatureGates, "KubeletCredentialProviders")
+
+		// Remove --feature-gate MixedProtocolLBService, ServiceInternalTrafficPolicy, ServiceIPStaticSubrange, EndpointSliceTerminatingCondition  starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117237
+		invalidFeatureGates = append(invalidFeatureGates, "MixedProtocolLBService", "ServiceInternalTrafficPolicy", "ServiceIPStaticSubrange", "EndpointSliceTerminatingCondition")
+
+		// Remove --feature-gate WindowsHostProcessContainers starting with 1.28
+		// Reference: https://github.com/kubernetes/kubernetes/pull/117570
+		invalidFeatureGates = append(invalidFeatureGates, "WindowsHostProcessContainers")
+	}
 	removeInvalidFeatureGates(o.KubernetesConfig.KubeletConfig, invalidFeatureGates)
 
 	// Master-specific kubelet config changes go here

--- a/pkg/api/defaults-kubelet_test.go
+++ b/pkg/api/defaults-kubelet_test.go
@@ -985,6 +985,33 @@ func TestKubeletConfigFeatureGates(t *testing.T) {
 		t.Fatalf("got unexpected '--feature-gates' kubelet config value for \"--feature-gates\": \"\": %s",
 			k["--feature-gates"])
 	}
+
+	// test user-overrides, removal of feature gates for k8s versions >= 1.28
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.28.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = make(map[string]string)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	featuregate128 := "AdvancedAuditing=true,CSIMigrationGCE=true,CSIStorageCapacity=true,DelegateFSGroupToCSIDriver=true,DevicePlugins=true,DisableAcceleratorUsageMetrics=true,DryRun=true,EndpointSliceTerminatingCondition=true,KubeletCredentialProviders=true,MixedProtocolLBService=true,NetworkPolicyStatus=true,PodHasNetworkCondition=true,PodSecurity=true,ServiceIPStaticSubrange=true,ServiceInternalTrafficPolicy=true,UserNamespacesStatelessPodsSupport=true,WindowsHostProcessContainers=true"
+	k["--feature-gates"] = featuregate128
+	featuregate128Sanitized := "ExecProbeTimeout=true,RotateKubeletServerCertificate=true"
+	cs.setKubeletConfig(false)
+	if k["--feature-gates"] != featuregate128Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n kubelet config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.28.0", featuregate128, k["--feature-gates"], featuregate128Sanitized)
+	}
+
+	// test user-overrides, no removal of feature gates for k8s versions < 1.27
+	cs = CreateMockContainerService("testcluster", defaultTestClusterVer, 3, 2, false)
+	cs.Properties.OrchestratorProfile.OrchestratorVersion = "1.27.0"
+	cs.Properties.OrchestratorProfile.KubernetesConfig.APIServerConfig = make(map[string]string)
+	k = cs.Properties.OrchestratorProfile.KubernetesConfig.KubeletConfig
+	k["--feature-gates"] = featuregate128
+	featuregate127Sanitized := "AdvancedAuditing=true,CSIMigrationGCE=true,CSIStorageCapacity=true,DelegateFSGroupToCSIDriver=true,DevicePlugins=true,DisableAcceleratorUsageMetrics=true,DryRun=true,EndpointSliceTerminatingCondition=true,ExecProbeTimeout=true,KubeletCredentialProviders=true,MixedProtocolLBService=true,NetworkPolicyStatus=true,PodHasNetworkCondition=true,PodSecurity=true,RotateKubeletServerCertificate=true,ServiceIPStaticSubrange=true,ServiceInternalTrafficPolicy=true,UserNamespacesStatelessPodsSupport=true,WindowsHostProcessContainers=true"
+	cs.setKubeletConfig(false)
+	if k["--feature-gates"] != featuregate127Sanitized {
+		t.Fatalf("got unexpected '--feature-gates' for %s \n kubelet config original value  %s \n, expected sanitized value: %s \n, actual sanitized value: %s \n ",
+			"1.27.0", featuregate128, k["--feature-gates"], featuregate127Sanitized)
+	}
 }
 
 func TestKubeletStrongCipherSuites(t *testing.T) {

--- a/pkg/api/defaults.go
+++ b/pkg/api/defaults.go
@@ -1157,6 +1157,19 @@ func removeInvalidFeatureGates(m map[string]string, invalidFeatureGates []string
 	m["--feature-gates"] = removeKeys(m["--feature-gates"], invalidFeatureGates)
 }
 
+// removeInvalidFeatureGates removes specified invalid --feature-gates
+func replaceFlags(m map[string]string, replacedflags map[string]string) {
+	for old, new := range replacedflags {
+		if v, ok := m[old]; ok {
+			// Create the new flag name
+			m[new] = v
+
+			// Remove the old flag name
+			delete(m, old)
+		}
+	}
+}
+
 // removeKeys takes a input of strings matching a pattern []string{"foo=bar","key=val"}
 // removes from this input the given input keys e.g.: "foo"
 // and returns a single, comma-delimited, concatenated string of all remaining key/val string values, e.g.: "key=val"

--- a/pkg/api/vlabs/validate_test.go
+++ b/pkg/api/vlabs/validate_test.go
@@ -4611,7 +4611,7 @@ func TestValidateCustomCloudProfile(t *testing.T) {
 				Location: "testlocation",
 				Properties: &Properties{
 					CustomCloudProfile: &CustomCloudProfile{
-						IdentitySystem: "invalidIdentySytem",
+						IdentitySystem: "invalidIdentySystem",
 						PortalURL:      "https://portal.testlocation.cotoso.com",
 					},
 				},


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
- In Kubernetes v1.28, several flags and feature gates were removed.
  Users with existing api-models containing such a flag or feature gate would get broken deployments and upgrades. This PR will automatically remove the flag even if the user specifies it, for k8s v1.28+.
- Added proper unit tests for all removed flags and feature gates.

| Feature gates | PR |
|----------|----------|
| AdvancedAuditing | [kubernetes/kubernetes#118763](https://github.com/kubernetes/kubernetes/pull/118763)|
| CSIMigrationGCE   | [kubernetes/kubernetes#117055](https://github.com/kubernetes/kubernetes/pull/117055)|
| CSIStorageCapacity    | [kubernetes/kubernetes#118018](https://github.com/kubernetes/kubernetes/pull/118018)|
| DelegateFSGroupToCSIDriver    | [kubernetes/kubernetes#117655](https://github.com/kubernetes/kubernetes/pull/117655)     |
| DevicePlugins    | [kubernetes/kubernetes#118763](https://github.com/kubernetes/kubernetes/pull/118763)|
| DisableAcceleratorUsageMetrics    | [kubernetes/kubernetes#114068](https://github.com/kubernetes/kubernetes/pull/114068)|
| EndpointSliceTerminatingCondition, MixedProtocolLBService,ServiceIPStaticSubrange,ServiceInternalTrafficPolicy | [kubernetes/kubernetes#117237](https://github.com/kubernetes/kubernetes/pull/117237)|
| PodSecurity    | [kubernetes/kubernetes#114068](https://github.com/kubernetes/kubernetes/pull/114068)|
| WindowsHostProcessContainers    | [kubernetes/kubernetes#117570](https://github.com/kubernetes/kubernetes/pull/117570)|
| NetworkPolicyStatus    | [kubernetes/kubernetes#115843](https://github.com/kubernetes/kubernetes/pull/115843)|
| PodHasNetworkCondition    | |
| UserNamespacesStatelessPodsSupport    | [kubernetes/kubernetes#118691](https://github.com/kubernetes/kubernetes/pull/118691)|


- flag replacement
[The deprecated flag --lock-object-namespace and --lock-object-name have been removed from kube-scheduler. Please use --leader-elect-resource-namespace and --leader-elect-resource-name or ComponentConfig instead to configure those parameters.](https://github.com/kubernetes/kubernetes/pull/119130)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->



**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [X] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [X] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
