### PR TITLE
ci: Add SkipAzLogin and CheckIngressIPOnly parameters

### DIFF
--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -26,6 +26,7 @@ import (
 
 // Config holds global test configuration
 type Config struct {
+	SkipAzLogin                        bool          `envconfig:"SKIP_AZ_LOGIN" default:"false"`
 	SkipTest                           bool          `envconfig:"SKIP_TEST" default:"false"`
 	SkipLogsCollection                 bool          `envconfig:"SKIP_LOGS_COLLECTION" default:"true"`
 	Orchestrator                       string        `envconfig:"ORCHESTRATOR" default:"kubernetes"`

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -64,6 +64,7 @@ type Config struct {
 	AddNodePoolInput                   string `envconfig:"ADD_NODE_POOL_INPUT" default:""`
 	TestPVC                            bool   `envconfig:"TEST_PVC" default:"false"`
 	CleanPVC                           bool   `envconfig:"CLEAN_PVC" default:"true"`
+	CheckIngressIPOnly                 bool   `envconfig:"CHECK_INGRESS_IP_ONLY" default:"false"`
 	SubscriptionID                     string `envconfig:"SUBSCRIPTION_ID"`
 	ClientID                           string `envconfig:"CLIENT_ID"`
 	ClientSecret                       string `envconfig:"CLIENT_SECRET"`

--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -1779,7 +1779,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we can connect to the ELB service on the service IP")
-				err = sELB.ValidateWithRetry("(Welcome to nginx)", 30*time.Second, cfg.Timeout)
+				err = sELB.ValidateWithRetry("(Welcome to nginx)", cfg.CheckIngressIPOnly, 30*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Ensuring we can connect to the ELB service from another pod")
@@ -1793,7 +1793,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
 				}
-				err = sELB.ValidateWithRetry("(Welcome to nginx)", 30*time.Second, cfg.Timeout)
+				err = sELB.ValidateWithRetry("(Welcome to nginx)", cfg.CheckIngressIPOnly, 30*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				err = sELB.Delete(util.DefaultDeleteRetries)
@@ -2223,7 +2223,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", cfg.CheckIngressIPOnly, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
@@ -2253,7 +2253,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(5))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", cfg.CheckIngressIPOnly, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
@@ -2277,7 +2277,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				Expect(len(iisPods)).To(Equal(2))
 
 				By("Verifying that the service is reachable and returns the default IIS start page")
-				err = iisService.ValidateWithRetry("(IIS Windows Server)", sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", cfg.CheckIngressIPOnly, sleepBetweenRetriesWhenWaitingForPodReady, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Checking that each pod can reach the internet")
@@ -2298,7 +2298,7 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 					log.Printf("%s\n", string(out))
 					Expect(err).NotTo(HaveOccurred())
 				}
-				err = iisService.ValidateWithRetry("(IIS Windows Server)", 30*time.Second, cfg.Timeout)
+				err = iisService.ValidateWithRetry("(IIS Windows Server)", cfg.CheckIngressIPOnly, 30*time.Second, cfg.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Verifying pods & services can be deleted")

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -63,10 +63,10 @@ func main() {
 		log.Fatalf("Error while trying to setup azure account: %s\n", err)
 	}
 
-	err := acct.Login()
-	if err != nil {
-		log.Fatalf("Error while trying to login to azure account! %s\n", err)
-	}
+	// err := acct.Login()
+	// if err != nil {
+	// 	log.Fatalf("Error while trying to login to azure account! %s\n", err)
+	// }
 
 	err = acct.SetSubscription()
 	if err != nil {

--- a/test/e2e/runner.go
+++ b/test/e2e/runner.go
@@ -63,10 +63,12 @@ func main() {
 		log.Fatalf("Error while trying to setup azure account: %s\n", err)
 	}
 
-	// err := acct.Login()
-	// if err != nil {
-	// 	log.Fatalf("Error while trying to login to azure account! %s\n", err)
-	// }
+	if !cfg.SkipAzLogin {
+		err := acct.Login()
+		if err != nil {
+			log.Fatalf("Error while trying to login to azure account! %s\n", err)
+		}
+	}
 
 	err = acct.SetSubscription()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This PR adds new parameters to the E2E test framework, `SkipAzLogin` and `CheckIngressIPOnly`. By default, they are set to false, so that no changes are needed to our Hub test suites. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
