### PR TITLE
ci: re-enable deployment error unit tests

### DIFF
--- a/pkg/armhelpers/deploymentError.go
+++ b/pkg/armhelpers/deploymentError.go
@@ -70,13 +70,12 @@ func DeployTemplateSync(az AKSEngineClient, logger *logrus.Entry, resourceGroupN
 
 	// try to extract error from ARM Response
 	if deploymentExtended.Properties != nil && deploymentExtended.Properties.Error != nil && deploymentExtended.Properties.Error.Code != nil {
-		// logger.Infof("StatusCode: %d, Error: %s", deploymentExtended.Properties.Error.Code, deploymentExtended.Properties.Error.Details)
-		// deploymentErr.Response, _ = deploymentExtended.Properties.Error.Details.MarshalJSON()
+		logger.Infof("StatusCode: %s, Error: %s", *deploymentExtended.Properties.Error.Code, *deploymentExtended.Properties.Error.Message)
 		deploymentErr.StatusCode = *deploymentExtended.Properties.Error.Code
+		deploymentErr.Response, _ = json.Marshal(deploymentExtended.Properties.Error.Message)
 	} else {
 		logger.Errorf("Got error from Azure SDK without response from ARM")
 		// This is the failed sdk validation before calling ARM path
-		// deploymentErr.Response, _ = deploymentExtended.MarshalJSON()
 		deploymentErr.StatusCode = "0"
 		return deploymentErr
 	}

--- a/pkg/armhelpers/deploymentError_test.go
+++ b/pkg/armhelpers/deploymentError_test.go
@@ -3,146 +3,146 @@
 
 package armhelpers
 
-// import (
-// 	"testing"
+import (
+	"testing"
 
-// 	. "github.com/onsi/gomega"
-// 	"github.com/onsi/gomega/types"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 
-// 	resources "github.com/Azure/azure-sdk-for-go/profile/p20200901/resourcemanager/resources/armresources"
-// 	"github.com/pkg/errors"
-// 	log "github.com/sirupsen/logrus"
-// )
+	resources "github.com/Azure/azure-sdk-for-go/profile/p20200901/resourcemanager/resources/armresources"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
 
-// func TestDeployTemplateSync_Errors(t *testing.T) {
-// 	cases := []struct {
-// 		name                     string
-// 		mockClientFactory        func() *MockAKSEngineClient
-// 		topErrorMatcher          types.GomegaMatcher
-// 		provisioningStateMatcher types.GomegaMatcher
-// 		statusCodeMatcher        types.GomegaMatcher
-// 		responseMatcher          types.GomegaMatcher
-// 		opsListLenMatcher        types.GomegaMatcher
-// 	}{
-// 		{
-// 			name: "InternalOperationError",
-// 			mockClientFactory: func() *MockAKSEngineClient {
-// 				return &MockAKSEngineClient{
-// 					FailDeployTemplate: true,
-// 				}
-// 			},
-// 			topErrorMatcher:          Equal("DeployTemplate failed"),
-// 			provisioningStateMatcher: Equal(""),
-// 			statusCodeMatcher:        Equal("0"),
-// 			responseMatcher:          BeEmpty(),
-// 			opsListLenMatcher:        Equal(0),
-// 		},
-// 		{
-// 			name: "QuotaExceeded",
-// 			mockClientFactory: func() *MockAKSEngineClient {
-// 				return &MockAKSEngineClient{
-// 					FailDeployTemplateQuota: true,
-// 				}
-// 			},
-// 			topErrorMatcher:          ContainSubstring("resources.DeploymentsClient#CreateOrUpdate: Failure responding"),
-// 			provisioningStateMatcher: Equal(""),
-// 			statusCodeMatcher:        Equal("400"),
-// 			responseMatcher:          ContainSubstring("\"code\":\"QuotaExceeded\""),
-// 			opsListLenMatcher:        Equal(0),
-// 		},
-// 		{
-// 			name: "Conflict",
-// 			mockClientFactory: func() *MockAKSEngineClient {
-// 				return &MockAKSEngineClient{
-// 					FailDeployTemplateConflict: true,
-// 				}
-// 			},
-// 			topErrorMatcher:          ContainSubstring("At least one resource deployment operation failed."),
-// 			provisioningStateMatcher: Equal(""),
-// 			statusCodeMatcher:        Equal("200"),
-// 			responseMatcher:          ContainSubstring("\"code\":\"Conflict\""),
-// 			opsListLenMatcher:        Equal(0),
-// 		},
-// 		{
-// 			name: "DeployErrorWithOperationsLists",
-// 			mockClientFactory: func() *MockAKSEngineClient {
-// 				return &MockAKSEngineClient{
-// 					FailDeployTemplateWithProperties: true,
-// 				}
-// 			},
-// 			topErrorMatcher:          ContainSubstring("At least one resource deployment operation failed."),
-// 			provisioningStateMatcher: Equal("Failed"),
-// 			statusCodeMatcher:        Equal("200"),
-// 			responseMatcher:          ContainSubstring("\"code\":\"Conflict\""),
-// 			opsListLenMatcher:        Equal(2),
-// 		},
-// 	}
+func TestDeployTemplateSync_Errors(t *testing.T) {
+	cases := []struct {
+		name                     string
+		mockClientFactory        func() *MockAKSEngineClient
+		topErrorMatcher          types.GomegaMatcher
+		provisioningStateMatcher types.GomegaMatcher
+		statusCodeMatcher        types.GomegaMatcher
+		responseMatcher          types.GomegaMatcher
+		opsListLenMatcher        types.GomegaMatcher
+	}{
+		{
+			name: "InternalOperationError",
+			mockClientFactory: func() *MockAKSEngineClient {
+				return &MockAKSEngineClient{
+					FailDeployTemplate: true,
+				}
+			},
+			topErrorMatcher:          Equal("DeployTemplate failed"),
+			provisioningStateMatcher: Equal(""),
+			statusCodeMatcher:        Equal("0"),
+			responseMatcher:          BeEmpty(),
+			opsListLenMatcher:        Equal(0),
+		},
+		{
+			name: "QuotaExceeded",
+			mockClientFactory: func() *MockAKSEngineClient {
+				return &MockAKSEngineClient{
+					FailDeployTemplateQuota: true,
+				}
+			},
+			topErrorMatcher:          ContainSubstring("resources.DeploymentsClient#CreateOrUpdate: Failure responding"),
+			provisioningStateMatcher: Equal(""),
+			statusCodeMatcher:        Equal("400"),
+			responseMatcher:          ContainSubstring("\\\"code\\\":\\\"QuotaExceeded\\\""),
+			opsListLenMatcher:        Equal(0),
+		},
+		{
+			name: "Conflict",
+			mockClientFactory: func() *MockAKSEngineClient {
+				return &MockAKSEngineClient{
+					FailDeployTemplateConflict: true,
+				}
+			},
+			topErrorMatcher:          ContainSubstring("At least one resource deployment operation failed."),
+			provisioningStateMatcher: Equal(""),
+			statusCodeMatcher:        Equal("200"),
+			responseMatcher:          ContainSubstring("\\\"code\\\":\\\"Conflict\\\""),
+			opsListLenMatcher:        Equal(0),
+		},
+		{
+			name: "DeployErrorWithOperationsLists",
+			mockClientFactory: func() *MockAKSEngineClient {
+				return &MockAKSEngineClient{
+					FailDeployTemplateWithProperties: true,
+				}
+			},
+			topErrorMatcher:          ContainSubstring("At least one resource deployment operation failed."),
+			provisioningStateMatcher: Equal("Failed"),
+			statusCodeMatcher:        Equal("200"),
+			responseMatcher:          ContainSubstring("\\\"code\\\":\\\"Conflict\\\""),
+			opsListLenMatcher:        Equal(1),
+		},
+	}
 
-// 	for _, tc := range cases {
-// 		c := tc
-// 		t.Run(c.name, func(t *testing.T) {
-// 			t.Parallel()
+	for _, tc := range cases {
+		c := tc
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 
-// 			client := c.mockClientFactory()
-// 			logger := log.NewEntry(log.New())
-// 			err := DeployTemplateSync(client, logger, "rg1", "agentvm", map[string]interface{}{}, map[string]interface{}{})
-// 			g := NewGomegaWithT(t)
-// 			g.Expect(err).NotTo(BeNil())
-// 			deplErr, ok := err.(*DeploymentError)
-// 			g.Expect(ok).To(BeTrue())
-// 			g.Expect(deplErr.TopError.Error()).To(c.topErrorMatcher)
-// 			g.Expect(deplErr.ProvisioningState).To(c.provisioningStateMatcher)
-// 			g.Expect(deplErr.StatusCode).To(c.statusCodeMatcher)
-// 			g.Expect(string(deplErr.Response)).To(c.responseMatcher)
-// 			g.Expect(len(deplErr.OperationsLists)).To(c.opsListLenMatcher)
-// 		})
-// 	}
-// }
+			client := c.mockClientFactory()
+			logger := log.NewEntry(log.New())
+			err := DeployTemplateSync(client, logger, "rg1", "agentvm", map[string]interface{}{}, map[string]interface{}{})
+			g := NewGomegaWithT(t)
+			g.Expect(err).NotTo(BeNil())
+			deplErr, ok := err.(*DeploymentError)
+			g.Expect(ok).To(BeTrue())
+			g.Expect(deplErr.TopError.Error()).To(c.topErrorMatcher)
+			g.Expect(deplErr.ProvisioningState).To(c.provisioningStateMatcher)
+			g.Expect(deplErr.StatusCode).To(c.statusCodeMatcher)
+			g.Expect(string(deplErr.Response)).To(c.responseMatcher)
+			g.Expect(len(deplErr.OperationsLists)).To(c.opsListLenMatcher)
+		})
+	}
+}
 
-// func TestDeployTemplateSync_Success(t *testing.T) {
-// 	t.Parallel()
+func TestDeployTemplateSync_Success(t *testing.T) {
+	t.Parallel()
 
-// 	mockClient := &MockAKSEngineClient{}
-// 	logger := log.NewEntry(log.New())
-// 	err := DeployTemplateSync(mockClient, logger, "rg1", "agentvm", map[string]interface{}{}, map[string]interface{}{})
-// 	g := NewGomegaWithT(t)
-// 	g.Expect(err).To(BeNil())
-// }
+	mockClient := &MockAKSEngineClient{}
+	logger := log.NewEntry(log.New())
+	err := DeployTemplateSync(mockClient, logger, "rg1", "agentvm", map[string]interface{}{}, map[string]interface{}{})
+	g := NewGomegaWithT(t)
+	g.Expect(err).To(BeNil())
+}
 
-// func TestDeploymentError_Error(t *testing.T) {
-// 	t.Parallel()
+func TestDeploymentError_Error(t *testing.T) {
+	t.Parallel()
 
-// 	operations := make([]*resources.DeploymentOperation, 0)
-// 	id := "1234"
-// 	oID := "342"
-// 	provisioningState := "Failed"
-// 	status := map[string]interface{}{
-// 		"message": "sample status message",
-// 	}
-// 	properties := resources.DeploymentOperationProperties{
-// 		ProvisioningState: &provisioningState,
-// 		StatusMessage:     &status,
-// 	}
-// 	operation1 := &resources.DeploymentOperation{
-// 		ID:          &id,
-// 		OperationID: &oID,
-// 		Properties:  &properties,
-// 	}
-// 	operations = append(operations, operation1)
-// 	deploymentErr := &DeploymentError{
-// 		DeploymentName:    "agentvm",
-// 		ResourceGroup:     "rg1",
-// 		TopError:          errors.New("sample error"),
-// 		ProvisioningState: "Failed",
-// 		Response:          []byte("sample resp"),
-// 		StatusCode:        "500",
-// 		OperationsLists:   operations,
-// 	}
-// 	errString := deploymentErr.Error()
-// 	expected := `DeploymentName[agentvm] ResourceGroup[rg1] TopError[sample error] ProvisioningState[Failed] Operations[{
-//   "message": "sample status message"
-// }]`
-// 	if errString != expected {
-// 		t.Errorf("expected error with message %s, but got %s", expected, errString)
-// 	}
-// }
+	operations := make([]*resources.DeploymentOperation, 0)
+	id := "1234"
+	oID := "342"
+	provisioningState := "Failed"
+	status := map[string]interface{}{
+		"message": "sample status message",
+	}
+	properties := resources.DeploymentOperationProperties{
+		ProvisioningState: &provisioningState,
+		StatusMessage:     &status,
+	}
+	operation1 := &resources.DeploymentOperation{
+		ID:          &id,
+		OperationID: &oID,
+		Properties:  &properties,
+	}
+	operations = append(operations, operation1)
+	deploymentErr := &DeploymentError{
+		DeploymentName:    "agentvm",
+		ResourceGroup:     "rg1",
+		TopError:          errors.New("sample error"),
+		ProvisioningState: "Failed",
+		Response:          []byte("sample resp"),
+		StatusCode:        "500",
+		OperationsLists:   operations,
+	}
+	errString := deploymentErr.Error()
+	expected := `DeploymentName[agentvm] ResourceGroup[rg1] TopError[sample error] ProvisioningState[Failed] Operations[{
+  "message": "sample status message"
+}]`
+	if errString != expected {
+		t.Errorf("expected error with message %s, but got %s", expected, errString)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
This PR adds back the `deploymentErr.Response` field and re-enables deployment error unit tests.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [x] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
