### PR TITLE
ci: Output AIB release notes and cgmanifest to customization.log 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,36 +7,8 @@ on:
     paths:
       - 'releases/CHANGELOG*.md'
 
-env:
-  LINUX_NODE_IMAGE_SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
-  LINUX_NODE_IMAGE_RESOURCE_GROUP: ${{vars.LINUX_NODE_IMAGE_RESOURCE_GROUP}}
-  LINUX_NODE_IMAGE_GALLERY: ${{vars.LINUX_NODE_IMAGE_GALLERY}}
-  LINUX_NODE_IMAGE_NAME: ${{vars.LINUX_NODE_IMAGE_NAME}}
-  LINUX_NODE_IMAGE_VERSION: 2024.032.1
-  WINDOWS_NODE_IMAGE_SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
-  WINDOWS_NODE_IMAGE_RESOURCE_GROUP: ${{vars.WINDOWS_NODE_IMAGE_RESOURCE_GROUP}}
-  WINDOWS_NODE_IMAGE_GALLERY: ${{vars.WINDOWS_NODE_IMAGE_GALLERY}}
-  WINDOWS_NODE_IMAGE_NAME: ${{vars.WINDOWS_NODE_IMAGE_NAME}}
-  WINDOWS_NODE_IMAGE_VERSION: 2024.032.1
-
 jobs:
-  sig_image_versions:
-    runs-on: ubuntu-latest
-    outputs:
-      LINUX_NODE_IMAGE_VERSION: ${{ env.LINUX_NODE_IMAGE_VERSION }}
-      WINDOWS_NODE_IMAGE_VERSION: ${{ env.WINDOWS_NODE_IMAGE_VERSION }}
-    steps:
-      - run: echo "Exposing sig image version variables"
-  validate-no-egress:
-    needs: sig_image_versions
-    uses: ./.github/workflows/test-vhd-no-egress.yaml
-    with:
-      from_branch: ''
-      LINUX_NODE_IMAGE_VERSION: ${{ needs.sig_image_versions.outputs.LINUX_NODE_IMAGE_VERSION }}
-      WINDOWS_NODE_IMAGE_VERSION: ${{ needs.sig_image_versions.outputs.WINDOWS_NODE_IMAGE_VERSION }}
-    secrets: inherit
   build:
-    needs: validate-no-egress
     runs-on: ubuntu-latest
     permissions:
       contents: write 
@@ -80,54 +52,6 @@ jobs:
       - name: print git status after build
         run: |
           git status
-      - name: Validate 1.27 + containerd E2E
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          ORCHESTRATOR_RELEASE: "1.27"
-          CLUSTER_DEFINITION: "examples/e2e-tests/kubernetes/release/default/definition.json"
-          SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
-          CLIENT_ID: ${{ secrets.TEST_AZURE_SP_ID }}
-          CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
-          LOCATION: "eastus"
-          TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
-          USE_MANAGED_IDENTITY: true
-          MSI_USER_ASSIGNED_ID: ${{ secrets.MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E }}
-          CREATE_VNET: true
-          CLEANUP_ON_EXIT: true
-          CLEANUP_IF_FAIL: true
-          GINKGO_SKIP: ""
-          STABILITY_ITERATIONS: "0"
-          RETAIN_SSH: false
-          CONTAINER_RUNTIME: "containerd"
-          BLOCK_SSH: true
-          SKIP_LOGS_COLLECTION: true
-          AZURE_CORE_ONLY_SHOW_ERRORS: true
-          DISTRO: "aks-ubuntu-20.04"
-        run: make test-kubernetes
-      - name: Validate 1.28 + containerd E2E
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          ORCHESTRATOR_RELEASE: "1.28"
-          CLUSTER_DEFINITION: "examples/e2e-tests/kubernetes/release/default/definition.json"
-          SUBSCRIPTION_ID: ${{ secrets.TEST_AZURE_SUB_ID }}
-          CLIENT_ID: ${{ secrets.TEST_AZURE_SP_ID }}
-          CLIENT_SECRET: ${{ secrets.TEST_AZURE_SP_PW }}
-          LOCATION: "eastus"
-          TENANT_ID: ${{ secrets.TEST_AZURE_TENANT_ID }}
-          USE_MANAGED_IDENTITY: true
-          MSI_USER_ASSIGNED_ID: ${{ secrets.MSI_USER_ASSIGNED_ID_AKS_ENGINE_E2E }}
-          CREATE_VNET: true
-          CLEANUP_ON_EXIT: true
-          CLEANUP_IF_FAIL: true
-          GINKGO_SKIP: ""
-          STABILITY_ITERATIONS: "0"
-          RETAIN_SSH: false
-          CONTAINER_RUNTIME: "containerd"
-          BLOCK_SSH: true
-          SKIP_LOGS_COLLECTION: true
-          AZURE_CORE_ONLY_SHOW_ERRORS: true
-          DISTRO: "aks-ubuntu-20.04"
-        run: make test-kubernetes
       - name: Remove untracked files created during workflow steps
         run: git ls-files --others --exclude-standard -z | xargs -0 -r rm
       - name: Add local tag

--- a/vhd/packer/configure-windows-vhd-phase2.ps1
+++ b/vhd/packer/configure-windows-vhd-phase2.ps1
@@ -50,20 +50,15 @@ function Get-ContainerImages {
     foreach ($image in $imagesToPull) {
         & ctr.exe -n k8s.io images pull $image >> $containerdImagePullNotesFilePath
     }
+    # List images and log the output
+    Write-Log "Begin listing containerd images"
+    $imagesList = & ctr.exe -n k8s.io images list
+    foreach ($line in $imagesList) {
+        Write-Output $line
+    }
+    Write-Log "End listing containerd images"
     Stop-Job  -Name containerd
     Remove-Job -Name containerd
-
-    # Read and log the contents of the file
-    if (Test-Path $containerdImagePullNotesFilePath) {
-        $fileContent = Get-Content $containerdImagePullNotesFilePath
-        Write-Log "Begin reading file: $containerdImagePullNotesFilePath"
-        foreach ($line in $fileContent) {
-            Write-Output $line
-        }
-        Write-Log "Finished reading file: $containerdImagePullNotesFilePath"
-    } else {
-        Write-Log "File not found: $containerdImagePullNotesFilePath"
-    }
 }
 
 function Get-FilesToCacheOnVHD {

--- a/vhd/packer/configure-windows-vhd-phase2.ps1
+++ b/vhd/packer/configure-windows-vhd-phase2.ps1
@@ -48,10 +48,22 @@ function Get-ContainerImages {
     # CSE will configure and register containerd as a service at deployment time
     Start-Job -Name containerd -ScriptBlock { containerd.exe }
     foreach ($image in $imagesToPull) {
-        & ctr.exe -n k8s.io images pull $image > $containerdImagePullNotesFilePath
+        & ctr.exe -n k8s.io images pull $image >> $containerdImagePullNotesFilePath
     }
     Stop-Job  -Name containerd
     Remove-Job -Name containerd
+
+    # Read and log the contents of the file
+    if (Test-Path $containerdImagePullNotesFilePath) {
+        $fileContent = Get-Content $containerdImagePullNotesFilePath
+        Write-Log "Begin reading file: $containerdImagePullNotesFilePath"
+        foreach ($line in $fileContent) {
+            Write-Output $line
+        }
+        Write-Log "Finished reading file: $containerdImagePullNotesFilePath"
+    } else {
+        Write-Log "File not found: $containerdImagePullNotesFilePath"
+    }
 }
 
 function Get-FilesToCacheOnVHD {

--- a/vhd/packer/configure-windows-vhd-phase2.ps1
+++ b/vhd/packer/configure-windows-vhd-phase2.ps1
@@ -50,7 +50,6 @@ function Get-ContainerImages {
     foreach ($image in $imagesToPull) {
         & ctr.exe -n k8s.io images pull $image >> $containerdImagePullNotesFilePath
     }
-    # List images and log the output
     Write-Log "Begin listing containerd images"
     $imagesList = & ctr.exe -n k8s.io images list
     foreach ($line in $imagesList) {

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -444,7 +444,6 @@ apt list --installed \
   ))
 }' > ${VHD_CG_MANIFEST}
 
-# Function to output file contents with delineation
 output_file_contents() {
     local filepath=$1
 

--- a/vhd/packer/install-dependencies.sh
+++ b/vhd/packer/install-dependencies.sh
@@ -443,3 +443,18 @@ apt list --installed \
   }
   ))
 }' > ${VHD_CG_MANIFEST}
+
+# Function to output file contents with delineation
+output_file_contents() {
+    local filepath=$1
+
+    if [ -f "$filepath" ]; then
+        echo "===== Begin contents of $filepath ====="
+        cat "$filepath"
+        echo "===== End contents of $filepath ====="
+    else
+        echo "File not found: $filepath"
+    fi
+}
+output_file_contents "$VHD_LOGS_FILEPATH"
+output_file_contents "$VHD_CG_MANIFEST"

--- a/vhd/packer/write-release-notes-windows.ps1
+++ b/vhd/packer/write-release-notes-windows.ps1
@@ -123,3 +123,15 @@ Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes | Out-Stri
 
 # Ensure proper encoding is set for release notes file
 [IO.File]::ReadAllText($releaseNotesFilePath) | Out-File -Encoding utf8 $releaseNotesFilePath
+
+# Read and log the contents of the file
+if (Test-Path $releaseNotesFilePath) {
+    $fileContent = Get-Content $releaseNotesFilePath
+    Write-Output "Begin reading file: $releaseNotesFilePath"
+    foreach ($line in $fileContent) {
+        Write-Output $line
+    }
+    Write-Output "Finished reading file: $releaseNotesFilePath"
+} else {
+    Write-Output "File not found: $releaseNotesFilePath"
+}

--- a/vhd/packer/write-release-notes-windows.ps1
+++ b/vhd/packer/write-release-notes-windows.ps1
@@ -124,7 +124,6 @@ Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes | Out-Stri
 # Ensure proper encoding is set for release notes file
 [IO.File]::ReadAllText($releaseNotesFilePath) | Out-File -Encoding utf8 $releaseNotesFilePath
 
-# Read and log the contents of the file
 if (Test-Path $releaseNotesFilePath) {
     $fileContent = Get-Content $releaseNotesFilePath
     Write-Output "===== Begin contents of $releaseNotesFilePath ====="

--- a/vhd/packer/write-release-notes-windows.ps1
+++ b/vhd/packer/write-release-notes-windows.ps1
@@ -127,11 +127,11 @@ Log ($displayObjects | Format-Table -Property File, Sha256, SizeBytes | Out-Stri
 # Read and log the contents of the file
 if (Test-Path $releaseNotesFilePath) {
     $fileContent = Get-Content $releaseNotesFilePath
-    Write-Output "Begin reading file: $releaseNotesFilePath"
+    Write-Output "===== Begin contents of $releaseNotesFilePath ====="
     foreach ($line in $fileContent) {
         Write-Output $line
     }
-    Write-Output "Finished reading file: $releaseNotesFilePath"
+    Write-Output "===== End contents of $releaseNotesFilePath ====="
 } else {
     Write-Output "File not found: $releaseNotesFilePath"
 }


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
- This is a temporary mitigation to get VHD release notes and cgmanifest.json during AIB VHD pipeline. 
   - Note that when the image builder resource group is created, it must be manually locked so that the AIB customization.log and storage account will not be deleted by AIB pipeline after successful image creation. 
   - In the future, we should add a proper step to copy out the VHD release notes and cgmanifest.json.
- Removed validation steps in release.yaml, these steps should be done by ADO pipelines (test vhd no egress and PR E2E) before triggering release.yaml.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
