### PR TITLE
fix: remove guest agent before sysprep to run windows cse on hub

### DIFF
--- a/vhd/aib/AKSeImageTemplateWindows.json
+++ b/vhd/aib/AKSeImageTemplateWindows.json
@@ -154,6 +154,19 @@
                         "inline": [
                             "[concat('& c:\\akse-cache\\write-release-notes-windows.ps1 -BUILD_NUMBER ',parameters('build_number'),' -BUILD_ID ',parameters('build_id'),' -BUILD_REPO ',parameters('build_repo'),' -BUILD_BRANCH ',parameters('github_branch_name'),' -BUILD_COMMIT ',parameters('git_version'))]"
                         ]
+                    },
+                    {
+                        "type": "PowerShell",
+                        "name": "run sysprep phase1",
+                        "runElevated": true,
+                        "scriptUri": "[uri('https://raw.githubusercontent.com/Azure/aks-engine-azurestack/',concat(parameters('github_branch_name'),'/vhd/packer/sysprep-phase1.ps1'))]"
+                    },
+                    {
+                        "type": "File",
+                        "name": "copy sysprep phase2 script",
+                        "runElevated": true,
+                        "sourceUri": "[uri('https://raw.githubusercontent.com/Azure/aks-engine-azurestack/',concat(parameters('github_branch_name'),'/vhd/packer/sysprep-phase2.ps1'))]",
+                        "destination":"c:\\DeprovisioningScript.ps1"
                     }
                 ],
                 "distribute": 

--- a/vhd/packer/configure-windows-vhd-phase2.ps1
+++ b/vhd/packer/configure-windows-vhd-phase2.ps1
@@ -48,7 +48,7 @@ function Get-ContainerImages {
     # CSE will configure and register containerd as a service at deployment time
     Start-Job -Name containerd -ScriptBlock { containerd.exe }
     foreach ($image in $imagesToPull) {
-        & ctr.exe -n k8s.io images pull $image >> $containerdImagePullNotesFilePath
+        & ctr.exe -n k8s.io images pull $image > $containerdImagePullNotesFilePath
     }
     Write-Log "Begin listing containerd images"
     $imagesList = & ctr.exe -n k8s.io images list

--- a/vhd/packer/sysprep-phase1.ps1
+++ b/vhd/packer/sysprep-phase1.ps1
@@ -1,11 +1,14 @@
+$ErrorActionPreference = "Continue"
+
 # Stop and remove Azure Agents to enable use in Azure Stack
 # If deploying an Azure VM the agents will be re-added to the VMs at deployment time
 Stop-Service WindowsAzureGuestAgent
-Stop-Service WindowsAzureNetAgentSvc
+# Stop-Service WindowsAzureNetAgentSvc
 Stop-Service RdAgent
 & sc.exe delete WindowsAzureGuestAgent
-& sc.exe delete WindowsAzureNetAgentSvc
+# & sc.exe delete WindowsAzureNetAgentSvc
 & sc.exe delete RdAgent
+Write-Output '>>> Deleted Azure agents complete ...'
 
 # Remove the WindowsAzureGuestAgent registry key for sysprep 
 # This removes AzureGuestAgent from participating in sysprep 
@@ -26,11 +29,7 @@ $values | ForEach-Object {
     }
 }
 
-# run Sysprep
-if( Test-Path $Env:SystemRoot\\system32\\Sysprep\\unattend.xml ) {  Remove-Item $Env:SystemRoot\\system32\\Sysprep\\unattend.xml -Force }
-& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /mode:vm /quit
+# Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }
+# Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse -ErrorAction SilentlyContinue
 
-# when done clean up
-while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }
-Get-ChildItem c:\\WindowsAzure -Force | Sort-Object -Property FullName -Descending | ForEach-Object { try { Remove-Item -Path $_.FullName -Force -Recurse -ErrorAction SilentlyContinue; } catch { } }
-Remove-Item -Path WSMan:\\Localhost\\listener\\listener* -Recurse
+Write-Output '>>> Sysprep phase1 script complete ...'

--- a/vhd/packer/sysprep-phase2.ps1
+++ b/vhd/packer/sysprep-phase2.ps1
@@ -1,0 +1,17 @@
+if( Test-Path $Env:SystemRoot\system32\Sysprep\unattend.xml ) {
+  Write-Output '>>> Removing Sysprep\unattend.xml ...'
+  Remove-Item $Env:SystemRoot\system32\Sysprep\unattend.xml -Force
+}
+if (Test-Path $Env:SystemRoot\Panther\unattend.xml) {
+  Write-Output '>>> Removing Panther\unattend.xml ...'
+  Remove-Item $Env:SystemRoot\Panther\unattend.xml -Force
+}
+Write-Output '>>> Sysprepping VM ...'
+& $Env:SystemRoot\System32\Sysprep\Sysprep.exe /oobe /generalize /quiet /quit
+while($true) {
+  $imageState = (Get-ItemProperty HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Setup\State).ImageState
+  Write-Output $imageState
+  if ($imageState -eq 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { break }
+  Start-Sleep -s 5
+}
+Write-Output '>>> Sysprep complete ...'


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Hub requires a fixed version of guest agent. When building the VHD, the Azure VM's guest agent must be removed before running sysprep, so that the created VM on Hub can run the windows CSE.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [x] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
