### PR TITLE
fix: Fix ssh for windows nodes

### DIFF
--- a/parts/k8s/windowsinstallopensshfunc.ps1
+++ b/parts/k8s/windowsinstallopensshfunc.ps1
@@ -18,13 +18,39 @@ Install-OpenSSH {
             throw "OpenSSH is not available on this machine"
         }
 
+        # Somehow openssh client got added to Windows 2019 base image. 
+        # Remove openssh client in order to install the server.
+        Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
         Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
     }
     else
     {
-        Write-Log "OpenSSH Server service detected - skipping online install..."
+        if ($sshdService.Status -ne 'Running') {
+            Write-Log "OpenSSH Server service detected but not running. Reinstalling OpenSSH..."
+            # Somehow openssh client got added to Windows 2019 base image. 
+            # Remove openssh client in order to install the server.
+            Remove-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+            Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
+            Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+        }
+        else {
+            Write-Log "OpenSSH Server service detected and running - skipping online install..."
+        }
     }
 
+    # It’s by design that files within the C:\Windows\System32\ folder are not modifiable. 
+    # When the OpenSSH Server starts, it copies C:\windows\system32\openssh\sshd_config_default to C:\programdata\ssh\sshd_config, if the file does not already exist.
+    $OriginalConfigPath = "C:\windows\system32\OpenSSH\sshd_config_default"
+    $ConfigDirectory = "C:\programdata\ssh"
+    New-Item -ItemType Directory -Force -Path $ConfigDirectory
+    $ConfigPath = $ConfigDirectory + "\sshd_config"
+    Write-Log "Updating $ConfigPath for CVE-2023-48795"
+    $ModifiedConfigContents = Get-Content $OriginalConfigPath `
+        | %{ $_ -replace "#RekeyLimit default none", "$&`r`n# Disable cipher to mitigate CVE-2023-48795`r`nCiphers -chacha20-poly1305@openssh.com`r`nMacs -*-etm@openssh.com`r`n" }
+    Write-Log "Updating $ConfigPath for CVE-2006-5051"
+    $ModifiedConfigContents = $ModifiedConfigContents.Replace("#LoginGraceTime 2m", "LoginGraceTime 0")
+    Stop-Service sshd
+    Out-File -FilePath $ConfigPath -InputObject $ModifiedConfigContents -Encoding UTF8
     Start-Service sshd
 
     if (!(Test-Path "$adminpath")) {

--- a/vhd/packer/configure-windows-vhd-phase1.ps1
+++ b/vhd/packer/configure-windows-vhd-phase1.ps1
@@ -38,6 +38,9 @@ function Disable-WindowsUpdates {
 
 function Install-OpenSSH {
     Write-Log "Installing OpenSSH Server"
+    # Somehow openssh client got added to Windows 2019 base image. 
+    # Remove openssh client in order to install the server.
+    Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
     Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 }
 

--- a/vhd/packer/configure-windows-vhd.ps1
+++ b/vhd/packer/configure-windows-vhd.ps1
@@ -186,6 +186,9 @@ function Install-Docker {
 
 function Install-OpenSSH {
     Write-Log "Installing OpenSSH Server"
+    # Somehow openssh client got added to Windows 2019 base image. 
+    # Remove openssh client in order to install the server.
+    Remove-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
     Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 }
 


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Since AKS Engine v0.81.1, we could not ssh into windows agent nodes. This PR fixes the issue. 

The root cause is the Windows server 2019 base image (since Oct 2024). Installing openssh server causes issues when the openssh client is installed and patched - due to the new way windows handles features. The solution is to remove the open ssh client before installing the open ssh server. 

Additionally this PR updates the ssh install script to address CVEs. This matches upstream AgentBaker's latest updates: https://github.com/Azure/AgentBaker/blob/master/vhdbuilder/packer/windows/configure-windows-vhd.ps1#L527

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [x] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [x] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [x] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
