### PR TITLE
fix: ensure --cloud-provider is always set to external in APIServerConfig

### DIFF
--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -143,6 +143,11 @@ func (cs *ContainerService) setAPIServerConfig() {
 		o.KubernetesConfig.APIServerConfig[key] = val
 	}
 
+	// Always set --cloud-provider to external if it exists
+	if _, exists := o.KubernetesConfig.APIServerConfig["--cloud-provider"]; exists {
+		o.KubernetesConfig.APIServerConfig["--cloud-provider"] = "external"
+	}
+
 	// Remove flags for secure communication to kubelet, if configured
 	if !to.Bool(o.KubernetesConfig.EnableSecureKubelet) {
 		for _, key := range []string{"--kubelet-client-certificate", "--kubelet-client-key"} {


### PR DESCRIPTION
fix: ensure --cloud-provider is always set to external in APIServerConfig

<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [X] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [X] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
