### PR TITLE
test: update test for k8s 1.35 since NetworkUnavailable condition is no longer set or need

### DIFF
--- a/test/e2e/kubernetes/kubernetes_test.go
+++ b/test/e2e/kubernetes/kubernetes_test.go
@@ -783,8 +783,18 @@ var _ = Describe("Azure Container Cluster using the Kubernetes Orchestrator", fu
 				}
 
 				if !isMasterNode {
-					Expect(hasNetworkCondition).To(BeTrue(),
-						fmt.Sprintf("Linux agent node %s should have NetworkUnavailable condition", n.Metadata.Name))
+					// NetworkUnavailable condition is not consistently set by external cloud providers in K8s 1.34+
+					// so we only check for it in older versions
+					if common.IsKubernetesVersionGe(eng.ExpandedDefinition.Properties.OrchestratorProfile.OrchestratorVersion, "1.34.0") {
+						if hasNetworkCondition {
+							log.Printf("Linux agent node %s has NetworkUnavailable condition (optional in K8s 1.34+)", n.Metadata.Name)
+						} else {
+							log.Printf("Linux agent node %s has no NetworkUnavailable condition (expected in K8s 1.34+ with external cloud provider)", n.Metadata.Name)
+						}
+					} else {
+						Expect(hasNetworkCondition).To(BeTrue(),
+							fmt.Sprintf("Linux agent node %s should have NetworkUnavailable condition", n.Metadata.Name))
+					}
 				}
 			}
 		})


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
