### PR TITLE
fix: kube-apiserver cloud provider flags removal for k8s 1.33+

### DIFF
--- a/docs/topics/clusterdefinitions.md
+++ b/docs/topics/clusterdefinitions.md
@@ -649,8 +649,8 @@ Below is a list of apiserver options that are _not_ currently user-configurable,
 | "--requestheader-extra-headers-prefix" | "X-Remote-Extra-" (_if enableAggregatedAPIs is true_)                                   |
 | "--requestheader-group-headers"        | "X-Remote-Group" (_if enableAggregatedAPIs is true_)                                    |
 | "--requestheader-username-headers"     | "X-Remote-User" (_if enableAggregatedAPIs is true_)                                     |
-| "--cloud-provider"                     | "azure" (_unless useCloudControllerManager is true_) **Removed in Kubernetes 1.34+** |
-| "--cloud-config"                       | "/etc/kubernetes/azure.json" (_unless useCloudControllerManager is true_) **Removed in Kubernetes 1.34+** |
+| "--cloud-provider"                     | "azure" (_unless useCloudControllerManager is true_) **Removed in Kubernetes 1.33+** |
+| "--cloud-config"                       | "/etc/kubernetes/azure.json" (_unless useCloudControllerManager is true_) **Removed in Kubernetes 1.33+** |
 
 <a name="feat-scheduler-config"></a>
 

--- a/pkg/api/defaults-apiserver.go
+++ b/pkg/api/defaults-apiserver.go
@@ -522,8 +522,8 @@ func (cs *ContainerService) overrideAPIServerConfig() {
 		o.KubernetesConfig.APIServerConfig["--enable-admission-plugins"] = newPlugins
 	}
 
-	// Remove cloud provider flags for K8s 1.34+ (in-tree cloud providers fully removed)
-	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.34.0") {
+	// Remove cloud provider flags for K8s 1.33+ (in-tree cloud providers fully removed)
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.33.0") {
 		delete(o.KubernetesConfig.APIServerConfig, "--cloud-provider")
 		delete(o.KubernetesConfig.APIServerConfig, "--cloud-config")
 	}

--- a/pkg/api/defaults-controller-manager.go
+++ b/pkg/api/defaults-controller-manager.go
@@ -433,8 +433,8 @@ func (cs *ContainerService) setControllerManagerConfig() {
 	}
 	removeInvalidFeatureGates(o.KubernetesConfig.ControllerManagerConfig, invalidFeatureGates)
 
-	// Remove cloud provider flags for K8s 1.34+ (in-tree cloud providers fully removed)
-	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.34.0") {
+	// Remove cloud provider flags for K8s 1.33+ (in-tree cloud providers fully removed)
+	if common.IsKubernetesVersionGe(o.OrchestratorVersion, "1.33.0") {
 		delete(o.KubernetesConfig.ControllerManagerConfig, "--cloud-provider")
 		delete(o.KubernetesConfig.ControllerManagerConfig, "--cloud-config")
 	}

--- a/releases/CHANGELOG-v0.85.0.md
+++ b/releases/CHANGELOG-v0.85.0.md
@@ -1,7 +1,8 @@
 
 <a name="v0.85.0"></a>
-# [v0.85.0] - 2026-05-26
+# [v0.85.0] - 2026-06-09
 ### Bug Fixes 🐞
+- kube-apiserver cloud provider flags removal for k8s 1.33+ ([#396](https://github.com/Azure/aks-engine-azurestack/issues/396))
 - update golang and image versions ([#391](https://github.com/Azure/aks-engine-azurestack/issues/391))
 - additional unsupported flags to remove ([#389](https://github.com/Azure/aks-engine-azurestack/issues/389))
 - update k8s components image reference paths to v2 ([#388](https://github.com/Azure/aks-engine-azurestack/issues/388))


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
