### PR TITLE
sec: fix security issue with Windows patches extension

### DIFF
--- a/extensions/windows-patches/README.md
+++ b/extensions/windows-patches/README.md
@@ -154,6 +154,16 @@ $full_url | Set-Clipboard
 
 The scripts output both the URL and SHA-256 hash. Add them to `extensionParameters` as shown above, keeping URI and hash order aligned. The PowerShell script also puts the URL on the Windows clipboard. Do not share a URL containing a SAS token; keep it private.
 
+## Local Tests
+
+Run the extension's unit tests from the repository root:
+
+```powershell
+.\extensions\windows-patches\v1\run-tests.ps1
+```
+
+The runner requires PowerShell 7 and installs Pester 5.7.1 for the current user when necessary, then runs `installPatches.tests.ps1`. When launched from Windows PowerShell 5.1, it automatically relaunches itself with `pwsh` if available. The tests mock downloads, process execution, test-signing changes, and reboot scheduling; they do not modify the local system.
+
 ## Troubleshooting
 
 Extension execution output is logged to files found under the following directory on the target virtual machine.

--- a/extensions/windows-patches/README.md
+++ b/extensions/windows-patches/README.md
@@ -7,12 +7,16 @@ This extension will install Windows Security and Preview updates. It's useful fo
 
 ## Configuration
 
-|Name               |Required| Acceptable Value     |
-|-------------------|--------|----------------------|
-|name               |yes     | windows-patches      |
-|version            |yes     | v1                   |
-|rootURL            |optional| `https://raw.githubusercontent.com/Azure/aks-engine-azurestack/master/` or any repo with the same extensions/... directory structure |
-|extensionParameters|yes     | comma-delimited list of URIs enclosed with ' such as `'https://privateupdates.domain.ext/Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe', 'https://privateupdates.domain.ext/Windows10.0-KB123456-x64-InstallForTestingPurposesOnly.exe'` |
+| Name                  | Required | Acceptable value                               |
+| --------------------- | -------- | ---------------------------------------------- |
+| `name`                | yes      | `windows-patches`                              |
+| `version`             | yes      | `v1`                                           |
+| `rootURL`             | no       | HTTPS URL containing the extension directory   |
+| `extensionParameters` | yes      | HTTPS URI and SHA-256 pairs                    |
+
+`rootURL` defaults to `https://raw.githubusercontent.com/Azure/aks-engine-azurestack/master/`. A custom repository must use the same `extensions/...` directory structure.
+
+For `extensionParameters`, provide comma-delimited HTTPS URIs followed by `-SHA256Hashes` and a corresponding comma-delimited list of hashes. Each hash must contain 64 hexadecimal characters and correspond to the URI at the same position. Obtain hashes from a trusted source independently of the patch download location. Append `-EnableTestSigning` only when a private test-signed executable requires it.
 
 ## Example
 
@@ -34,11 +38,13 @@ This extension will install Windows Security and Preview updates. It's useful fo
         "name": "windows-patches",
         "version": "v1",
         "rootURL": "https://raw.githubusercontent.com/Azure/aks-engine-azurestack/master/",
-        "extensionParameters": "'https://mypatches.blob.core.windows.net/hotfix3692/Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe?sp=r&st=2018-08-17T00:25:01Z&se=2018-09-17T08:25:01Z&spr=https&sv=2017-11-09&sig=0000000000%3D&sr=b', 'http://download.windowsupdate.com/c/msdownload/update/software/secu/2018/08/windows10.0-kb4343909-x64_f931af6d56797388715fe3b0d97569af7aebdae6.msu'"
+        "extensionParameters": "'https://mypatches.blob.core.windows.net/hotfix3692/Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe?sp=r&st=2018-08-17T00:25:01Z&se=2018-09-17T08:25:01Z&spr=https&sv=2017-11-09&sig=0000000000%3D&sr=b', 'https://download.windowsupdate.com/c/msdownload/update/software/secu/2018/08/windows10.0-kb4343909-x64_f931af6d56797388715fe3b0d97569af7aebdae6.msu' -SHA256Hashes '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef', 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789' -EnableTestSigning"
       }
     ]
     ...
 ```
+
+The hashes in this example are placeholders. Replace them with the hashes published by the patch provider or calculated from files obtained through a trusted channel. Omit `-EnableTestSigning` unless Microsoft Support explicitly requires test-signing mode for a private patch.
 
 ## Supported Orchestrators
 
@@ -55,17 +61,17 @@ If you would like to include a cumulative update as part of your deployment that
 3. Scroll down to "How to get this update", and click on the ["Microsoft Update Catalog"](http://catalog.update.microsoft.com/v7/site/Search.aspx?q=KB4343909) link.
 4. Find the row for `(year)-(month) Cumulative Update for Windows Server 2016 ((1709 or 1803)) for x64-based Systems (KB######)`, and click the "Download" button.
 5. This will pop up a new window with a hyperlink such as `windows10.0-kb4343909-x64_f931af6d56797388715fe3b0d97569af7aebdae6.msu`. Copy that link.
-6. Include that link in the `extensionParameters` as shown in the [Example](#Example)
+6. Obtain the update's published SHA-256 hash through a trusted channel.
+7. Include the link and hash in `extensionParameters` as shown in the [Example](#example).
 
 ### Supplied by Microsoft support
 
 Once you have downloaded a private patch from Microsoft support, it needs to be put in an Azure-accessible location. The easiest way to do this is to create an [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-create-storage-account#blob-storage-accounts) account. Once uploaded, you can create a private link with a key to access it that will work with this extension.
 
-> This requires [Enabling Loading of Test Signed Drivers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/the-testsigning-boot-configuration-option), and is not for use on production systems. If you provide a private patch as an `.exe` file, then test signing will be enabled automatically by this extension.
+> Some private patches require [Enabling Loading of Test Signed Drivers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/the-testsigning-boot-configuration-option), which weakens code-integrity enforcement and is not for use on production systems. Test signing is disabled by default. Add `-EnableTestSigning` to `extensionParameters` only when Microsoft Support explicitly requires it.
 
 1. If you haven't already, install the [Azure CLI](https://docs.microsoft.com/cli/azure/get-started-with-az-cli2), and run `az login` to log in to Azure
 2. Copy the sample below for either bash (Linux, Mac, or WSL), or PowerShell (Windows), and modify the variables at the top.
-
 
 #### Using az cli and bash to upload the patch
 
@@ -77,6 +83,7 @@ export storage_account_name=privatepatches
 export container_name=hotfix
 export blob_name=Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe
 export file_to_upload=Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe
+export patch_sha256=$(sha256sum "$file_to_upload" | cut -d ' ' -f 1)
 
 echo "Creating the group..."
 az group create --location $storage_location --resource-group $resource_group
@@ -102,6 +109,7 @@ export ABSURL=`az storage blob url --container-name $container_name --name $blob
 
 echo "Full URL including access token:"
 echo "$ABSURL?$TEMPORARY_SAS" | sed "s/\"//g"
+echo "SHA-256: $patch_sha256"
 ```
 
 #### Using az cli and PowerShell to upload the patch
@@ -113,6 +121,7 @@ $storage_account_name="privatepatches"
 $container_name="hotfix"
 $blob_name="Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe"
 $file_to_upload="Windows10.0-KB999999-x64-InstallForTestingPurposesOnly.exe"
+$PATCH_SHA256 = (Get-FileHash -LiteralPath $file_to_upload -Algorithm SHA256).Hash
 
 Write-Host "Creating the group..."
 az group create --location $storage_location --resource-group $resource_group
@@ -140,9 +149,10 @@ Write-Host "Full URL including access token:"
 $full_url = "$($ABSURL)?$($TEMPORARY_SAS)".Replace("""","")
 $full_url | Write-Host
 $full_url | Set-Clipboard
+"SHA-256: $PATCH_SHA256" | Write-Host
 ```
 
-The last line of the script will output a URL, and also put it on the Windows clipboard. Copy it into `extensionParameters` as shown in the sample above. Do not share this URL, keep it private.
+The scripts output both the URL and SHA-256 hash. Add them to `extensionParameters` as shown above, keeping URI and hash order aligned. The PowerShell script also puts the URL on the Windows clipboard. Do not share a URL containing a SAS token; keep it private.
 
 ## Troubleshooting
 

--- a/extensions/windows-patches/v1/installPatches.ps1
+++ b/extensions/windows-patches/v1/installPatches.ps1
@@ -7,17 +7,19 @@
 #  4 - patch validation failure
 
 param(
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNullOrEmpty()]
     [string[]] $URIs,
 
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNullOrEmpty()]
-    [ValidatePattern('^[A-Fa-f0-9]{64}$')]
     [string[]] $SHA256Hashes,
 
     [switch] $EnableTestSigning
 )
+
+function New-PatchException([string] $Message, [int] $ExitCode)
+{
+    $exception = [InvalidOperationException]::new($Message)
+    $exception.Data["ExitCode"] = $ExitCode
+    return $exception
+}
 
 function DownloadAndVerifyFile([Uri] $URI, [string] $FullName, [string] $ExpectedSHA256)
 {
@@ -27,116 +29,142 @@ function DownloadAndVerifyFile([Uri] $URI, [string] $FullName, [string] $Expecte
         Invoke-WebRequest -UseBasicParsing -Uri $URI.AbsoluteUri -OutFile $FullName
     } catch {
         Remove-Item -LiteralPath $FullName -Force -ErrorAction SilentlyContinue
-        Write-Error $_
-        exit 2
+        throw (New-PatchException -Message $_.Exception.Message -ExitCode 2)
     }
 
     $actualSHA256 = (Get-FileHash -LiteralPath $FullName -Algorithm SHA256).Hash
     if (-not [string]::Equals($actualSHA256, $ExpectedSHA256, [StringComparison]::OrdinalIgnoreCase)) {
         Remove-Item -LiteralPath $FullName -Force -ErrorAction SilentlyContinue
-        Write-Error "SHA-256 verification failed for $($URI.GetLeftPart([UriPartial]::Path))"
-        exit 4
+        throw (New-PatchException -Message "SHA-256 verification failed for $($URI.GetLeftPart([UriPartial]::Path))" -ExitCode 4)
     }
 
     Write-Host "Verified SHA-256 for $([IO.Path]::GetFileName($FullName))"
 }
 
-if ($URIs.Count -ne $SHA256Hashes.Count) {
-    Write-Error "Each patch URI must have a corresponding SHA-256 hash"
-    exit 4
+function Get-PatchDefinitions([string[]] $URIs, [string[]] $SHA256Hashes)
+{
+    if ($null -eq $URIs -or $URIs.Count -eq 0 -or $null -eq $SHA256Hashes -or $SHA256Hashes.Count -eq 0) {
+        throw (New-PatchException -Message "Patch URIs and SHA-256 hashes are required" -ExitCode 4)
+    }
+
+    if ($URIs.Count -ne $SHA256Hashes.Count) {
+        throw (New-PatchException -Message "Each patch URI must have a corresponding SHA-256 hash" -ExitCode 4)
+    }
+
+    $patches = @()
+    for ($index = 0; $index -lt $URIs.Count; $index++) {
+        if ($SHA256Hashes[$index] -notmatch '^[A-Fa-f0-9]{64}$') {
+            throw (New-PatchException -Message "Each SHA-256 hash must contain 64 hexadecimal characters" -ExitCode 4)
+        }
+
+        $parsedURI = $null
+        if (-not [Uri]::TryCreate($URIs[$index], [UriKind]::Absolute, [ref] $parsedURI)) {
+            throw (New-PatchException -Message "Patch URI must be an absolute URI" -ExitCode 4)
+        }
+
+        if ($parsedURI.Scheme -ine [Uri]::UriSchemeHttps) {
+            throw (New-PatchException -Message "Patch URI must use HTTPS: $($parsedURI.GetLeftPart([UriPartial]::Path))" -ExitCode 4)
+        }
+
+        $fileName = [IO.Path]::GetFileName($parsedURI.LocalPath)
+        if ([string]::IsNullOrWhiteSpace($fileName)) {
+            throw (New-PatchException -Message "Patch URI must identify a file" -ExitCode 4)
+        }
+
+        $extension = [IO.Path]::GetExtension($fileName).ToLowerInvariant()
+        if ($extension -ne ".exe" -and $extension -ne ".msu") {
+            throw (New-PatchException -Message "This script extension doesn't know how to install $extension files" -ExitCode 3)
+        }
+
+        $patches += [PSCustomObject]@{
+            URI = $parsedURI
+            ExpectedSHA256 = $SHA256Hashes[$index]
+            FileName = $fileName
+            Extension = $extension
+            FullName = [IO.Path]::Combine($env:TEMP, $fileName)
+        }
+    }
+
+    return $patches
 }
 
-$patches = @()
-for ($index = 0; $index -lt $URIs.Count; $index++) {
-    $parsedURI = $null
-    if (-not [Uri]::TryCreate($URIs[$index], [UriKind]::Absolute, [ref] $parsedURI)) {
-        Write-Error "Patch URI must be an absolute URI"
-        exit 4
-    }
-
-    if ($parsedURI.Scheme -ine [Uri]::UriSchemeHttps) {
-        Write-Error "Patch URI must use HTTPS: $($parsedURI.GetLeftPart([UriPartial]::Path))"
-        exit 4
-    }
-
-    $fileName = [IO.Path]::GetFileName($parsedURI.LocalPath)
-    if ([string]::IsNullOrWhiteSpace($fileName)) {
-        Write-Error "Patch URI must identify a file"
-        exit 4
-    }
-
-    $extension = [IO.Path]::GetExtension($fileName).ToLowerInvariant()
-    if ($extension -ne ".exe" -and $extension -ne ".msu") {
-        Write-Error "This script extension doesn't know how to install $extension files"
-        exit 3
-    }
-
-    $patches += [PSCustomObject]@{
-        URI = $parsedURI
-        ExpectedSHA256 = $SHA256Hashes[$index]
-        FileName = $fileName
-        Extension = $extension
-        FullName = [IO.Path]::Combine($env:TEMP, $fileName)
-    }
+function Wait-PatchProcess($Process)
+{
+    Wait-Process -InputObject $Process
+    return $Process.ExitCode
 }
 
-$testSigningEnabled = $false
-$patches | ForEach-Object {
-    $patch = $_
-    Write-Host "Processing $($patch.URI.GetLeftPart([UriPartial]::Path))"
-    DownloadAndVerifyFile -URI $patch.URI -FullName $patch.FullName -ExpectedSHA256 $patch.ExpectedSHA256
+function Install-Patches([string[]] $URIs, [string[]] $SHA256Hashes, [switch] $EnableTestSigning)
+{
+    $patches = @(Get-PatchDefinitions -URIs $URIs -SHA256Hashes $SHA256Hashes)
+    $testSigningEnabled = $false
+    $patches | ForEach-Object {
+        $patch = $_
+        Write-Host "Processing $($patch.URI.GetLeftPart([UriPartial]::Path))"
+        DownloadAndVerifyFile -URI $patch.URI -FullName $patch.FullName -ExpectedSHA256 $patch.ExpectedSHA256
 
-    switch ($patch.Extension) {
-        ".exe" {
-            if ($EnableTestSigning -and -not $testSigningEnabled) {
-                Write-Warning "Enabling Windows test-signing mode for executable patches"
-                $bcdedit = Start-Process -Passthru -Wait -FilePath bcdedit.exe -ArgumentList "/set {current} testsigning on"
-                if ($bcdedit.ExitCode -ne 0) {
-                    Write-Error "Failed to enable Windows test-signing mode, exitcode $($bcdedit.ExitCode)"
-                    exit 1
+        switch ($patch.Extension) {
+            ".exe" {
+                if ($EnableTestSigning -and -not $testSigningEnabled) {
+                    Write-Warning "Enabling Windows test-signing mode for executable patches"
+                    $bcdedit = Start-Process -Passthru -Wait -FilePath bcdedit.exe -ArgumentList "/set {current} testsigning on"
+                    if ($bcdedit.ExitCode -ne 0) {
+                        throw (New-PatchException -Message "Failed to enable Windows test-signing mode, exitcode $($bcdedit.ExitCode)" -ExitCode 1)
+                    }
+                    $testSigningEnabled = $true
                 }
-                $testSigningEnabled = $true
+
+                Write-Host "Starting $($patch.FullName)"
+                $proc = Start-Process -Passthru -FilePath $patch.FullName -ArgumentList "/q /norestart"
+                $exitCode = Wait-PatchProcess -Process $proc
+                switch ($exitCode)
+                {
+                    0 {
+                        Write-Host "Finished running $($patch.FullName)"
+                    }
+                    3010 {
+                        Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
+                    }
+                    Default {
+                        throw (New-PatchException -Message "Error running $($patch.FullName), exitcode $exitCode" -ExitCode 1)
+                    }
+                }
             }
-
-            Write-Host "Starting $($patch.FullName)"
-            $proc = Start-Process -Passthru -FilePath $patch.FullName -ArgumentList "/q /norestart"
-            Wait-Process -InputObject $proc
-            switch ($proc.ExitCode)
-            {
-                0 {
-                    Write-Host "Finished running $($patch.FullName)"
-                }
-                3010 {
-                    Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
-                }
-                Default {
-                    Write-Error "Error running $($patch.FullName), exitcode $($proc.ExitCode)"
-                    exit 1
+            ".msu" {
+                Write-Host "Installing $($patch.FullName)"
+                $proc = Start-Process -Passthru -FilePath wusa.exe -ArgumentList "`"$($patch.FullName)`" /quiet /norestart"
+                $exitCode = Wait-PatchProcess -Process $proc
+                switch ($exitCode)
+                {
+                    0 {
+                        Write-Host "Finished running $($patch.FullName)"
+                    }
+                    3010 {
+                        Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
+                    }
+                    Default {
+                        throw (New-PatchException -Message "Error running $($patch.FullName), exitcode $exitCode" -ExitCode 1)
+                    }
                 }
             }
         }
-        ".msu" {
-            Write-Host "Installing $($patch.FullName)"
-            $proc = Start-Process -Passthru -FilePath wusa.exe -ArgumentList "`"$($patch.FullName)`" /quiet /norestart"
-            Wait-Process -InputObject $proc
-            switch ($proc.ExitCode)
-            {
-                0 {
-                    Write-Host "Finished running $($patch.FullName)"
-                }
-                3010 {
-                    Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
-                }
-                Default {
-                    Write-Error "Error running $($patch.FullName), exitcode $($proc.ExitCode)"
-                    exit 1
-                }
-            }
-        }
     }
+
+    # No failures, schedule reboot now
+    schtasks /create /TN RebootAfterPatch /RU SYSTEM /TR "shutdown.exe /r /t 0 /d 2:17" /SC ONCE /ST $(([System.DateTime]::Now + [timespan]::FromMinutes(5)).ToString("HH:mm")) /V1 /Z
 }
 
-# No failures, schedule reboot now
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        Install-Patches -URIs $URIs -SHA256Hashes $SHA256Hashes -EnableTestSigning:$EnableTestSigning
+        exit 0
+    } catch {
+        Write-Error $_.Exception.Message
+        $exitCode = $_.Exception.Data["ExitCode"]
+        if ($null -eq $exitCode) {
+            $exitCode = 1
+        }
 
-schtasks /create /TN RebootAfterPatch /RU SYSTEM /TR "shutdown.exe /r /t 0 /d 2:17" /SC ONCE /ST $(([System.DateTime]::Now + [timespan]::FromMinutes(5)).ToString("HH:mm")) /V1 /Z
-exit 0
+        exit $exitCode
+    }
+}

--- a/extensions/windows-patches/v1/installPatches.ps1
+++ b/extensions/windows-patches/v1/installPatches.ps1
@@ -4,78 +4,134 @@
 #  1 - install failure
 #  2 - download failure
 #  3 - unrecognized patch extension
+#  4 - patch validation failure
 
 param(
-    [string[]] $URIs
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string[]] $URIs,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [ValidatePattern('^[A-Fa-f0-9]{64}$')]
+    [string[]] $SHA256Hashes,
+
+    [switch] $EnableTestSigning
 )
 
-function DownloadFile([string] $URI, [string] $fullName)
+function DownloadAndVerifyFile([Uri] $URI, [string] $FullName, [string] $ExpectedSHA256)
 {
     try {
-        Write-Host "Downloading $URI"
+        Write-Host "Downloading $($URI.GetLeftPart([UriPartial]::Path))"
         $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest -UseBasicParsing $URI -OutFile $fullName
+        Invoke-WebRequest -UseBasicParsing -Uri $URI.AbsoluteUri -OutFile $FullName
     } catch {
+        Remove-Item -LiteralPath $FullName -Force -ErrorAction SilentlyContinue
         Write-Error $_
         exit 2
     }
+
+    $actualSHA256 = (Get-FileHash -LiteralPath $FullName -Algorithm SHA256).Hash
+    if (-not [string]::Equals($actualSHA256, $ExpectedSHA256, [StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $FullName -Force -ErrorAction SilentlyContinue
+        Write-Error "SHA-256 verification failed for $($URI.GetLeftPart([UriPartial]::Path))"
+        exit 4
+    }
+
+    Write-Host "Verified SHA-256 for $([IO.Path]::GetFileName($FullName))"
 }
 
+if ($URIs.Count -ne $SHA256Hashes.Count) {
+    Write-Error "Each patch URI must have a corresponding SHA-256 hash"
+    exit 4
+}
 
-$URIs | ForEach-Object {
-    Write-Host "Processing $_"
-    $uri = $_
-    $pathOnly = $uri
-    if ($pathOnly.Contains("?"))
-    {
-        $pathOnly = $pathOnly.Split("?")[0]
+$patches = @()
+for ($index = 0; $index -lt $URIs.Count; $index++) {
+    $parsedURI = $null
+    if (-not [Uri]::TryCreate($URIs[$index], [UriKind]::Absolute, [ref] $parsedURI)) {
+        Write-Error "Patch URI must be an absolute URI"
+        exit 4
     }
-    $fileName = Split-Path $pathOnly -Leaf
-    $ext = [io.path]::GetExtension($fileName)
-    $fullName = [io.path]::Combine($env:TEMP, $fileName)
-    switch ($ext) {
+
+    if ($parsedURI.Scheme -ine [Uri]::UriSchemeHttps) {
+        Write-Error "Patch URI must use HTTPS: $($parsedURI.GetLeftPart([UriPartial]::Path))"
+        exit 4
+    }
+
+    $fileName = [IO.Path]::GetFileName($parsedURI.LocalPath)
+    if ([string]::IsNullOrWhiteSpace($fileName)) {
+        Write-Error "Patch URI must identify a file"
+        exit 4
+    }
+
+    $extension = [IO.Path]::GetExtension($fileName).ToLowerInvariant()
+    if ($extension -ne ".exe" -and $extension -ne ".msu") {
+        Write-Error "This script extension doesn't know how to install $extension files"
+        exit 3
+    }
+
+    $patches += [PSCustomObject]@{
+        URI = $parsedURI
+        ExpectedSHA256 = $SHA256Hashes[$index]
+        FileName = $fileName
+        Extension = $extension
+        FullName = [IO.Path]::Combine($env:TEMP, $fileName)
+    }
+}
+
+$testSigningEnabled = $false
+$patches | ForEach-Object {
+    $patch = $_
+    Write-Host "Processing $($patch.URI.GetLeftPart([UriPartial]::Path))"
+    DownloadAndVerifyFile -URI $patch.URI -FullName $patch.FullName -ExpectedSHA256 $patch.ExpectedSHA256
+
+    switch ($patch.Extension) {
         ".exe" {
-            Start-Process -FilePath bcdedit.exe -ArgumentList "/set {current} testsigning on" -Wait
-            DownloadFile -URI $uri -fullName $fullName
-            Write-Host "Starting $fullName"
-            $proc = Start-Process -Passthru -FilePath "$fullName" -ArgumentList "/q /norestart"
+            if ($EnableTestSigning -and -not $testSigningEnabled) {
+                Write-Warning "Enabling Windows test-signing mode for executable patches"
+                $bcdedit = Start-Process -Passthru -Wait -FilePath bcdedit.exe -ArgumentList "/set {current} testsigning on"
+                if ($bcdedit.ExitCode -ne 0) {
+                    Write-Error "Failed to enable Windows test-signing mode, exitcode $($bcdedit.ExitCode)"
+                    exit 1
+                }
+                $testSigningEnabled = $true
+            }
+
+            Write-Host "Starting $($patch.FullName)"
+            $proc = Start-Process -Passthru -FilePath $patch.FullName -ArgumentList "/q /norestart"
             Wait-Process -InputObject $proc
             switch ($proc.ExitCode)
             {
                 0 {
-                    Write-Host "Finished running $fullName"
+                    Write-Host "Finished running $($patch.FullName)"
                 }
                 3010 {
-                    Write-Host "Finished running $fullName. Reboot required to finish patching."
+                    Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
                 }
                 Default {
-                    Write-Error "Error running $fullName, exitcode $($proc.ExitCode)"
+                    Write-Error "Error running $($patch.FullName), exitcode $($proc.ExitCode)"
                     exit 1
                 }
             }
         }
         ".msu" {
-            DownloadFile -URI $uri -fullName $fullName
-            Write-Host "Installing $localPath"
-            $proc = Start-Process -Passthru -FilePath wusa.exe -ArgumentList "$fullName /quiet /norestart"
+            Write-Host "Installing $($patch.FullName)"
+            $proc = Start-Process -Passthru -FilePath wusa.exe -ArgumentList "`"$($patch.FullName)`" /quiet /norestart"
             Wait-Process -InputObject $proc
             switch ($proc.ExitCode)
             {
                 0 {
-                    Write-Host "Finished running $fullName"
+                    Write-Host "Finished running $($patch.FullName)"
                 }
                 3010 {
-                    Write-Host "Finished running $fullName. Reboot required to finish patching."
+                    Write-Host "Finished running $($patch.FullName). Reboot required to finish patching."
                 }
                 Default {
-                    Write-Error "Error running $fullName, exitcode $($proc.ExitCode)"
+                    Write-Error "Error running $($patch.FullName), exitcode $($proc.ExitCode)"
                     exit 1
                 }
             }
-        }
-        Default {
-            Write-Error "This script extension doesn't know how to install $ext files"
-            exit 3
         }
     }
 }

--- a/extensions/windows-patches/v1/installPatches.tests.ps1
+++ b/extensions/windows-patches/v1/installPatches.tests.ps1
@@ -1,0 +1,93 @@
+BeforeAll {
+    . $PSScriptRoot\installPatches.ps1
+    $validHash = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+}
+
+Describe 'Get-PatchDefinitions' {
+    It 'creates a patch definition for a valid HTTPS URI and SHA-256 hash' {
+        $patches = @(Get-PatchDefinitions -URIs 'https://example.test/patch.msu?token=secret' -SHA256Hashes $validHash)
+
+        $patches.Count | Should -Be 1
+        $patches[0].FileName | Should -Be 'patch.msu'
+        $patches[0].Extension | Should -Be '.msu'
+        $patches[0].ExpectedSHA256 | Should -Be $validHash
+    }
+
+    It 'rejects an HTTP URI' {
+        { Get-PatchDefinitions -URIs 'http://example.test/patch.msu' -SHA256Hashes $validHash } |
+            Should -Throw '*must use HTTPS*'
+    }
+
+    It 'rejects mismatched URI and hash counts' {
+        { Get-PatchDefinitions -URIs @('https://example.test/one.msu', 'https://example.test/two.msu') -SHA256Hashes $validHash } |
+            Should -Throw '*corresponding SHA-256 hash*'
+    }
+
+    It 'rejects a malformed SHA-256 hash' {
+        { Get-PatchDefinitions -URIs 'https://example.test/patch.msu' -SHA256Hashes 'not-a-hash' } |
+            Should -Throw '*64 hexadecimal characters*'
+    }
+
+    It 'rejects an unsupported patch extension' {
+        { Get-PatchDefinitions -URIs 'https://example.test/patch.zip' -SHA256Hashes $validHash } |
+            Should -Throw '*doesn''t know how to install*'
+    }
+}
+
+Describe 'DownloadAndVerifyFile' {
+    BeforeEach {
+        Mock Invoke-WebRequest
+        Mock Remove-Item
+    }
+
+    It 'accepts a matching SHA-256 hash without deleting the file' {
+        Mock Get-FileHash { [PSCustomObject]@{ Hash = $validHash.ToUpperInvariant() } }
+
+        { DownloadAndVerifyFile -URI 'https://example.test/patch.msu' -FullName 'TestDrive:\patch.msu' -ExpectedSHA256 $validHash } |
+            Should -Not -Throw
+
+        Should -Invoke Invoke-WebRequest -Times 1 -Exactly
+        Should -Invoke Remove-Item -Times 0 -Exactly
+    }
+
+    It 'deletes the file and rejects a mismatched SHA-256 hash' {
+        Mock Get-FileHash { [PSCustomObject]@{ Hash = ('f' * 64) } }
+
+        { DownloadAndVerifyFile -URI 'https://example.test/patch.msu' -FullName 'TestDrive:\patch.msu' -ExpectedSHA256 $validHash } |
+            Should -Throw '*SHA-256 verification failed*'
+
+        Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -eq 'TestDrive:\patch.msu' }
+    }
+
+    It 'deletes a partial file when the download fails' {
+        Mock Invoke-WebRequest { throw 'download failed' }
+
+        { DownloadAndVerifyFile -URI 'https://example.test/patch.msu' -FullName 'TestDrive:\patch.msu' -ExpectedSHA256 $validHash } |
+            Should -Throw '*download failed*'
+
+        Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -eq 'TestDrive:\patch.msu' }
+    }
+}
+
+Describe 'Install-Patches' {
+    BeforeEach {
+        Mock DownloadAndVerifyFile
+        Mock Start-Process { [PSCustomObject]@{ ExitCode = 0 } }
+        Mock Wait-PatchProcess { 0 }
+        Mock schtasks
+    }
+
+    It 'does not enable test signing by default' {
+        Install-Patches -URIs 'https://example.test/patch.exe' -SHA256Hashes $validHash
+
+        Should -Invoke Start-Process -Times 0 -Exactly -ParameterFilter { $FilePath -eq 'bcdedit.exe' }
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -like '*patch.exe' }
+    }
+
+    It 'enables test signing when explicitly requested for an executable patch' {
+        Install-Patches -URIs 'https://example.test/patch.exe' -SHA256Hashes $validHash -EnableTestSigning
+
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -eq 'bcdedit.exe' }
+        Should -Invoke Start-Process -Times 1 -Exactly -ParameterFilter { $FilePath -like '*patch.exe' }
+    }
+}

--- a/extensions/windows-patches/v1/run-tests.ps1
+++ b/extensions/windows-patches/v1/run-tests.ps1
@@ -1,0 +1,37 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+if ($PSVersionTable.PSEdition -eq 'Desktop') {
+    $pwsh = Get-Command pwsh.exe -ErrorAction SilentlyContinue
+    if ($null -eq $pwsh) {
+        throw "PowerShell 7 is required to bootstrap the local test dependencies. Install it and run this script again."
+    }
+
+    & $pwsh.Source -NoProfile -File $PSCommandPath
+    exit $LASTEXITCODE
+}
+
+$requiredPesterVersion = [Version]'5.7.1'
+$pester = Get-Module -ListAvailable Pester |
+    Where-Object { $_.Version -eq $requiredPesterVersion } |
+    Select-Object -First 1
+
+if ($null -eq $pester) {
+    Write-Host "Pester $requiredPesterVersion is not installed. Installing it for the current user..."
+    Install-Module Pester -Scope CurrentUser -RequiredVersion $requiredPesterVersion -Force -SkipPublisherCheck
+    $pester = Get-Module -ListAvailable Pester |
+        Where-Object { $_.Version -eq $requiredPesterVersion } |
+        Select-Object -First 1
+}
+
+Remove-Module Pester -Force -ErrorAction SilentlyContinue
+Import-Module $pester.Path -Force
+
+$configuration = New-PesterConfiguration
+$configuration.Run.Path = Join-Path $PSScriptRoot 'installPatches.tests.ps1'
+$configuration.Run.Exit = $true
+$configuration.Output.Verbosity = 'Detailed'
+
+Invoke-Pester -Configuration $configuration

--- a/extensions/windows-patches/v1/template.json
+++ b/extensions/windows-patches/v1/template.json
@@ -34,7 +34,7 @@
 			"type": "securestring",
 			"minLength": 0,
 			"metadata": {
-				"description": "Custom Parameter for Extension - comma delimited list of URIs"
+				"description": "HTTPS patch URIs followed by -SHA256Hashes and a corresponding comma-delimited list of SHA-256 hashes"
 			}
 		},
 		 "vmIndex": {


### PR DESCRIPTION
<!-- Thank you for helping AKS Engine with a pull request!
Use conventional commit messages, such as
  feat: add a knob to the frobnitz
or
  fix: repair hole in wumpus
And read this for faster PR reviews: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews -->

**Reason for Change**:
<!-- What does this PR improve or fix in AKS Engine? -->
Previously, the extension downloaded operator-provided files and executed them without validating their contents. It also automatically enabled Windows test-signing mode for executable patches.

Changes:
- Require a SHA-256 hash for every patch URI.
- Require all patch URIs to use HTTPS.
- Validate URI and hash counts before downloading files.
- Verify each downloaded file with Get-FileHash before execution.
- Delete downloaded files when hash verification fails.
- Add validation exit code 4.
- Make test-signing mode opt-in through -EnableTestSigning.
- Enable test signing only after the executable passes integrity verification.
- Avoid logging URI query strings that may contain SAS tokens.
- Update the ARM template parameter description.
- Update the extension documentation and examples with:
- SHA-256 generation instructions.
- HTTPS requirements.
- URI-to-hash positional pairing.
- Test-signing security guidance.

Configuration Change:
This is an intentional breaking security change. Existing configurations must change from:
`'PATCH_URI'`
to:
`'PATCH_URI' -SHA256Hashes '64_CHARACTER_SHA256'`
For multiple patches:
`'PATCH_URI_1', 'PATCH_URI_2' -SHA256Hashes 'SHA256_1', 'SHA256_2'`
The URI and hash positions must correspond. Add -EnableTestSigning only when Microsoft Support explicitly requires test-signing mode for a private patch.

Security Impact:
The extension now establishes an integrity barrier between downloading and executing patch files. Modified or unexpected files are rejected before they can reach Start-Process or wusa.exe.
HTTPS protects the download in transit, while the pinned SHA-256 hash verifies that the downloaded artifact is the expected file.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Addresses CWE-494 in the Windows patching extension by verifying the integrity of downloaded .exe and .msu patch files before installation.

**Credit Where Due**:

Does this change contain code from or inspired by another project?

- [ ] No
- [ ] Yes

If "Yes," did you notify that project's maintainers and provide attribution?

- [ ] No
- [ ] Yes

**Requirements**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] uses [conventional commit messages](https://www.conventionalcommits.org/)
  <!-- Common commit types:
        build: Build 🏭
        chore: Maintenance 🔧
        ci: Continuous Integration 💜
        docs: Documentation 📘
        feat: Features 🌈
        fix: Bug Fixes 🐞
        perf: Performance Improvements 🚀
        refactor: Code Refactoring 💎
        revert: Revert Change ◀️
        style: Code Style 🎶
        security: Security Fix 🛡️
        test: Testing 💚 -->
- [ ] includes documentation
- [ ] adds unit tests
- [ ] tested upgrade from previous version

**Notes**:
